### PR TITLE
Feature/zarr update (#54)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ name: Test
 
 on:
   push:
-    branches: [test]
+    branches: [feature/zarr-update]
   pull_request:
-    branches: [test]
+    branches: [feature/zarr-update]
 
 jobs:
   # ---- Job 1: 静态检查 + 单元测试 ----

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -25,13 +25,13 @@ if (!username || !password) {
 setup('authenticate', async ({ page }) => {
   await page.goto('/login')
 
-  await page.fill('input[placeholder="Username"]', username)
-  await page.fill('input[placeholder="Password"]', password)
+  await page.fill('input[placeholder="Username"]', process.env.E2E_USERNAME!)
+  await page.fill('input[placeholder="Password"]', process.env.E2E_PASSWORD!)
 
   await page.click('button:has-text("Sign In")')
 
-  // 等待登录完成并跳转到 /profile
-  await page.waitForURL('/profile')
+  // 等待登录完成，跳转到 /mydatasets 或 /profile
+  await page.waitForURL(/\/(mydatasets|profile)/)
   await page.waitForLoadState('networkidle')
 
   // 保存浏览器状态（token、localStorage、cookie）供后续测试复用

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -38,14 +38,14 @@ test.describe('Unauthenticated', () => {
 
     await page.goto('/login')
 
-    await page.fill('input[placeholder="Username"]', username)
-    await page.fill('input[placeholder="Password"]', password)
+    await page.fill('input[placeholder="Username"]', process.env.E2E_USERNAME!)
+    await page.fill('input[placeholder="Password"]', process.env.E2E_PASSWORD!)
 
     await page.click('button:has-text("Sign In")')
 
-    // 成功 toast + 跳转 /profile
+    // 成功 toast + 跳转
     await expect(page.locator('.toast')).toContainText('Login successful')
-    await expect(page).toHaveURL('/profile')
+    await expect(page).toHaveURL(/\/mydatasets/)
   })
 
   test('shows error with invalid credentials', async ({ page }) => {
@@ -162,12 +162,12 @@ test.describe('Authenticated', () => {
 
   // ── 路由守卫 + 持久化 ──
 
-  test('route guard — visiting /login redirects to /profile', async ({ page }) => {
-    await page.goto('/profile')    // 确保已登录
+  test('route guard — visiting /login redirects when already logged in', async ({ page }) => {
+    await page.goto('/mydatasets')    // 确保已登录
     await page.goto('/login')
 
-    // 已登录 → 踢回 /profile
-    await expect(page).toHaveURL('/profile')
+    // 已登录 → 踢回 /mydatasets 或 /profile
+    await expect(page).toHaveURL(/\/mydatasets/)
   })
 
   test('token persistence — survives page reload', async ({ page }) => {

--- a/e2e/datasets.spec.ts
+++ b/e2e/datasets.spec.ts
@@ -4,19 +4,303 @@ import { mkdtempSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
+/** 解析 "File Size:X.X KB/MB/GB" 为 MB */
+function sizeToMB(text: string | null): number {
+  if (!text) return Infinity
+  const m = text.match(/([\d.]+)\s*(KB|MB|GB|TB)/i)
+  if (!m) return Infinity
+  const v = parseFloat(m[1])
+  switch (m[2].toUpperCase()) {
+    case 'KB': return v / 1024
+    case 'MB': return v
+    case 'GB': return v * 1024
+    case 'TB': return v * 1024 * 1024
+    default: return Infinity
+  }
+}
+
+const MAX_DOWNLOAD_MB = 300
+
 /**
  * Datasets E2E 测试 — 真实后端
  * ==============================
- * PublicDatasets：公开页 /datasets
- * MyDatasets：需登录 /mydatasets
- *
- * 两页共用 DatasetList / DatasetCard / DatasetFilterBar / PaginationBar。
- *
- * 不测：空状态 / 错误状态（无法触发）、真删（不可逆）
+ * PublicDatasets：公开页 /datasets（依赖已有公开数据）
+ * MyDatasets：需登录 /mydatasets（先上传一个文件，基于该文件测试所有功能，最后删除）
  */
 
 // ============================================================
-// Public Datasets
+// My Datasets（需登录，自包含：上传 → 测试 → 删除）
+// ============================================================
+
+test.describe('My Datasets', () => {
+
+  /**
+   * Step 1 — 上传一个测试文件，确保账号上有数据供后续测试使用
+   */
+  test('upload — uploads a test dataset', async ({ page, browserName }) => {
+    test.skip(browserName === 'webkit', 'Linux WebKit 不支持 OPFS')
+
+    const imzml = `<?xml version="1.0" encoding="utf-8"?>
+<mzML xmlns="http://psi.hupo.org/ms/mzml" version="1.1">
+  <cvList><cv id="MS" fullName="PSI-MS" version="4.1.7"/></cvList>
+  <fileDescription><fileContent>
+    <cvParam accession="MS:1000127" name="centroid spectrum" value=""/>
+    <cvParam accession="IMS:1000030" name="continuous" value=""/>
+  </fileContent></fileDescription>
+  <referenceableParamGroupList>
+    <referenceableParamGroup id="common">
+      <cvParam accession="MS:1000130" name="positive scan" value=""/>
+      <cvParam accession="MS:1000075" name="MALDI" value=""/>
+      <cvParam accession="MS:1000084" name="TOF" value=""/>
+      <cvParam name="pixel size x" value="50"/>
+      <cvParam name="pixel size y" value="50"/>
+    </referenceableParamGroup>
+  </referenceableParamGroupList>
+  <run id="test" defaultInstrumentConfigurationRef="IC1">
+    <spectrumList count="0"/>
+  </run>
+</mzML>`
+
+    const dir = mkdtempSync(join(tmpdir(), 'mv-upload-'))
+    writeFileSync(join(dir, 'test_lyk_upload.imzML'), imzml)
+    writeFileSync(join(dir, 'test_lyk_upload.ibd'), randomBytes(1024))
+
+    try {
+      await page.goto('/mydatasets')
+      await page.getByRole('button', { name: 'Upload New Dataset' }).click()
+      await expect(page.getByText('Upload New Dataset (imzML + ibd)')).toBeVisible()
+
+      await page.locator('input[type="file"]').setInputFiles([
+        join(dir, 'test_lyk_upload.imzML'),
+        join(dir, 'test_lyk_upload.ibd'),
+      ])
+
+      await page.waitForTimeout(2000)
+      await expect(page.locator('#is_public')).not.toBeChecked()
+
+      const pickLabels = ['Organism', 'Organism Part', 'Condition', 'Sample Stabilization']
+      for (const label of pickLabels) {
+        const area = page.locator('.modal-box').locator(`label:has-text("${label}")`).first().locator('..')
+        await area.locator('select').click()
+        await page.keyboard.press('ArrowDown')
+        await page.keyboard.press('Enter')
+        await page.waitForTimeout(300)
+      }
+
+      const solventArea = page.locator('.modal-box').locator('label:has-text("Solvent")').locator('..')
+      await solventArea.locator('select').click()
+      await page.keyboard.press('ArrowDown')
+      await page.keyboard.press('Enter')
+      await page.waitForTimeout(300)
+      await solventArea.getByPlaceholder('e.g. 50').fill('50')
+      await solventArea.getByPlaceholder('e.g. 50').press('Enter')
+
+      await page.getByRole('button', { name: 'Confirm & Upload' }).click()
+
+      // 等上传完成 → 弹窗关闭
+      await expect(page.locator('.toast')).toContainText(/success|reused|complete/, { timeout: 120_000 })
+      await expect(page.getByText('Upload New Dataset (imzML + ibd)')).not.toBeVisible()
+
+      // 轮询 Refresh Status，等第一张卡变为 Uploaded
+      await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+      const deadline = Date.now() + 25_000
+      while (Date.now() < deadline) {
+        await page.getByRole('button', { name: 'Refresh Status' }).click()
+        await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+        const hasUploading = await page.getByRole('button', { name: 'Delete' })
+          .first()
+          .locator('..')
+          .getByText('Uploading')
+          .isVisible()
+          .catch(() => false)
+        if (!hasUploading) break
+        await page.waitForTimeout(5000)
+      }
+      await expect(
+        page.getByRole('button', { name: 'Delete' }).first().locator('..').getByText(/Uploaded|Failed/)
+      ).toBeVisible()
+    } finally {
+      try { rmSync(dir, { recursive: true }) } catch { /* ok */ }
+    }
+  })
+
+  /**
+   * Step 2 — 基于上传的数据测试页面加载
+   */
+  test('page loads with quota bar and dataset cards', async ({ page }) => {
+    await page.goto('/mydatasets')
+
+    await expect(page.locator('h1:has-text("My Datasets")')).toBeVisible()
+    await expect(page.getByPlaceholder('Search my datasets')).toBeVisible()
+
+    await expect(page.getByText(/Storage \d/)).toBeVisible()
+    await expect(page.getByText(/Files \d/)).toBeVisible()
+    await expect(page.getByText(/Processing \d/)).toBeVisible()
+    await expect(page.getByText(/Downloads \d/)).toBeVisible()
+
+    await expect(page.getByRole('button', { name: 'Upload New Dataset' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Refresh Status' })).toBeVisible()
+
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+    await expect(page.getByText('Organism:').first()).toBeVisible()
+  })
+
+  /**
+   * Step 3 — 卡片状态、可见性、删除按钮
+   */
+  test('each card shows status, visibility, and delete button', async ({ page }) => {
+    await page.goto('/mydatasets')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    await expect(
+      page.locator('button, div').filter({ hasText: /Uploaded|Uploading|Failed/ }).first()
+    ).toBeVisible()
+
+    await expect(
+      page.locator('button, div').filter({ hasText: /Public|Private/ }).first()
+    ).toBeVisible()
+
+    await expect(page.getByRole('button', { name: 'Delete' }).first()).toBeVisible()
+  })
+
+  /**
+   * Step 4 — 随机下载一张卡
+   */
+  test('download — triggers download on a random card', async ({ page }) => {
+    test.setTimeout(60_000)  // WebKit 下载偶发较慢
+    await page.goto('/mydatasets')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    const downloadBtns = page.locator('button').filter({ hasText: /Download/ })
+    await downloadBtns.first().waitFor({ state: 'visible', timeout: 10_000 })
+    const count = await downloadBtns.count()
+
+    // 过滤出文件 < 300MB 的卡片索引
+    const eligible: number[] = []
+    for (let i = 0; i < count; i++) {
+      const card = downloadBtns.nth(i).locator('..').locator('..')
+      const sizeText = await card.locator('p:has-text("File Size:")').innerText()
+      if (sizeToMB(sizeText) < MAX_DOWNLOAD_MB) eligible.push(i)
+    }
+    const pick = eligible.length > 0
+      ? eligible[Math.floor(Math.random() * eligible.length)]
+      : 0
+
+    const card = downloadBtns.nth(pick).locator('..').locator('..')
+    const cardName = await card.locator('h3').innerText()
+    await expect(card.locator('h3')).not.toBeEmpty()
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      downloadBtns.nth(pick).click(),
+    ])
+
+    const filename = download.suggestedFilename()
+    expect(filename).toContain(cardName!.replace('Dataset name: ', ''))
+
+    // 清理下载文件（WebKit 偶发超时，忽略）
+    try { await download.delete() } catch { /* ok */ }
+  })
+
+  test('download rate limit — second download is blocked', async ({ page }) => {
+    await page.goto('/mydatasets')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    const btns = page.locator('button').filter({ hasText: /Download/ })
+    const count = await btns.count()
+    const idx1 = Math.floor(Math.random() * count)
+    let idx2: number
+    if (count > 1) {
+      do { idx2 = Math.floor(Math.random() * count) } while (idx2 === idx1)
+    } else {
+      idx2 = idx1
+    }
+
+    await btns.nth(idx1).click()
+    await expect(page.locator('.toast')).toContainText('Download started')
+    await page.waitForTimeout(2000)
+
+    await btns.nth(idx2).click()
+    await expect(page.locator('.toast')).toContainText(/Download is limited/)
+    await page.waitForTimeout(1000)
+  })
+
+  /**
+   * Step 5 — Overview 跳转并验证内容，再 Back 返回
+   */
+  test('overview — navigates, shows content, then back', async ({ page }) => {
+    await page.goto('/mydatasets')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    const overviewBtns = page.getByRole('button', { name: 'Overview' })
+    await overviewBtns.first().waitFor({ state: 'visible', timeout: 10_000 })
+    const count = await overviewBtns.count()
+    const pick = count > 1 ? Math.floor(Math.random() * count) : 0
+    await overviewBtns.nth(pick).click()
+    await expect(page).toHaveURL(/\/overview/)
+    await expect(page.locator('.skeleton')).toHaveCount(0, { timeout: 15_000 })
+    await expect(page.locator('h1:has-text("Dataset Overview")')).toBeVisible()
+
+    const hasContent = await page.getByRole('button', { name: 'Download' }).isVisible().catch(() => false)
+    if (hasContent) {
+      await expect(page.getByText('Size', { exact: true })).toBeVisible()
+      await expect(page.getByText('MALDI Information')).toBeVisible()
+      await expect(page.getByText('Technical Details')).toBeVisible()
+    }
+
+    const backBtn = page.getByRole('button', { name: 'Back to My Datasets' })
+    await expect(backBtn).toBeVisible()
+    await backBtn.click()
+
+    await expect(page).toHaveURL(/\/mydatasets/)
+    await expect(page.getByText('Organism:').first()).toBeVisible()
+  })
+
+  /**
+   * Step 6 — 排序切换
+   */
+  test('sort — toggles between submission time and file size', async ({ page }) => {
+    await page.goto('/mydatasets')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    const sortSelect = page.locator('select:has(option[value="size_bytes"])')
+    await sortSelect.selectOption('size_bytes')
+    await page.waitForTimeout(300)
+
+    await expect(page.getByText('Organism:').first()).toBeVisible()
+    await expect(page.getByText('File Size:').first()).toBeVisible()
+  })
+
+  /**
+   * Step 7 — Filter 面板
+   */
+  test('filter bar — Add filter panel opens', async ({ page }) => {
+    await page.goto('/mydatasets')
+
+    await page.getByRole('button', { name: 'Add filter' }).click()
+
+    await expect(page.getByRole('button', { name: 'Apply' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Reset' })).toBeVisible()
+  })
+
+  /**
+   * Step 8 — 清理：删除第一个数据集
+   */
+  test('delete — removes the first (newest) dataset on the page', async ({ page, browserName }) => {
+    test.skip(browserName === 'webkit', 'Linux WebKit 没有上传，跳过删除避免误删真实数据')
+    await page.goto('/mydatasets')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    await page.getByRole('button', { name: 'Delete' }).first().click()
+    await expect(page.getByText('Are you sure you want to delete this dataset?')).toBeVisible()
+
+    await page.locator('.modal-box').getByRole('button', { name: 'Delete' }).click()
+    await expect(page.locator('.toast')).toContainText(/deleted/)
+  })
+})
+
+// ============================================================
+// Public Datasets（依赖已有的公开数据）
 // ============================================================
 
 test.describe('Public Datasets', () => {
@@ -42,7 +326,6 @@ test.describe('Public Datasets', () => {
     await page.goto('/datasets')
     await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
 
-    // 改成每页 5 条，确保能翻页
     const perPageSelect = page.locator('label:has-text("Per page")').locator('..').locator('select')
     await perPageSelect.selectOption('5')
 
@@ -57,22 +340,58 @@ test.describe('Public Datasets', () => {
     }
   })
 
+  test('sort — toggles between submission time and file size', async ({ page }) => {
+    await page.goto('/datasets')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    const sortSelect = page.locator('select:has(option[value="size_bytes"])')
+    await sortSelect.selectOption('size_bytes')
+    await page.waitForTimeout(300)
+
+    await expect(page.getByText('Organism:').first()).toBeVisible()
+    await expect(page.getByText('File Size:').first()).toBeVisible()
+  })
+
   test('clicking a card navigates to dataset overview', async ({ page }) => {
     await page.goto('/datasets')
     await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
 
-    await page.getByRole('button', { name: 'Overview' }).first().click()
+    const overviewBtns = page.getByRole('button', { name: 'Overview' })
+    await overviewBtns.first().waitFor({ state: 'visible', timeout: 10_000 })
+    const count = await overviewBtns.count()
+    const pick = count > 1 ? Math.floor(Math.random() * count) : 0
+    await overviewBtns.nth(pick).click()
 
     await expect(page).toHaveURL(/\/overview/)
     await expect(page.locator('.skeleton')).toHaveCount(0, { timeout: 15_000 })
     await expect(page.locator('h1:has-text("Dataset Overview")')).toBeVisible()
 
-    // 有数据或空状态都能过
-    const hasContent = await page.getByText('Biological Metadata').isVisible().catch(() => false)
+    const hasContent = await page.getByRole('button', { name: 'Download' }).isVisible().catch(() => false)
     if (hasContent) {
+      await expect(page.getByText('Size', { exact: true })).toBeVisible()
       await expect(page.getByText('MALDI Information')).toBeVisible()
       await expect(page.getByText('Technical Details')).toBeVisible()
     }
+  })
+
+  test('overview back button — returns to Public Datasets', async ({ page }) => {
+    await page.goto('/datasets')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    const overviewBtns = page.getByRole('button', { name: 'Overview' })
+    await overviewBtns.first().waitFor({ state: 'visible', timeout: 10_000 })
+    const count = await overviewBtns.count()
+    const pick = count > 1 ? Math.floor(Math.random() * count) : 0
+    await overviewBtns.nth(pick).click()
+    await expect(page).toHaveURL(/\/overview/)
+    await expect(page.locator('.skeleton')).toHaveCount(0, { timeout: 15_000 })
+
+    const backBtn = page.getByRole('button', { name: 'Back to Public Datasets' })
+    await expect(backBtn).toBeVisible()
+    await backBtn.click()
+
+    await expect(page).toHaveURL(/\/datasets/)
+    await expect(page.getByText('Organism:').first()).toBeVisible()
   })
 
   test('filter bar — Add filter panel opens', async ({ page }) => {
@@ -84,157 +403,61 @@ test.describe('Public Datasets', () => {
     await expect(page.getByRole('button', { name: 'Reset' })).toBeVisible()
   })
 
-  test('download — triggers download on first card', async ({ page }) => {
+  test('download — triggers download on a random card', async ({ page }) => {
+    test.setTimeout(60_000)  // WebKit 下载偶发较慢
     await page.goto('/datasets')
     await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
 
-    await page.getByRole('button', { name: 'Download' }).first().click()
+    const downloadBtns = page.locator('button').filter({ hasText: /Download/ })
+    await downloadBtns.first().waitFor({ state: 'visible', timeout: 10_000 })
+    const count = await downloadBtns.count()
 
-    await expect(page.locator('.toast')).toContainText(/Download/)
-  })
-})
-
-// ============================================================
-// My Datasets（需登录）
-// ============================================================
-
-test.describe.skip('My Datasets', () => {
-
-  test('page loads with quota bar and dataset cards', async ({ page }) => {
-    await page.goto('/mydatasets')
-
-    await expect(page.locator('h1:has-text("My Datasets")')).toBeVisible()
-    await expect(page.getByPlaceholder('Search my datasets')).toBeVisible()
-
-    await expect(page.getByText(/Storage \d/)).toBeVisible()
-    await expect(page.getByText(/Files \d/)).toBeVisible()
-    await expect(page.getByText(/Processing \d/)).toBeVisible()
-    await expect(page.getByText(/Downloads \d/)).toBeVisible()
-
-    await expect(page.getByRole('button', { name: 'Upload New Dataset' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Refresh Status' })).toBeVisible()
-
-    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
-    await expect(page.getByText('Organism:').first()).toBeVisible()
-  })
-
-  test('each card shows status, visibility, and delete button', async ({ page }) => {
-    await page.goto('/mydatasets')
-    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
-
-    await expect(
-      page.locator('button, div').filter({ hasText: /Uploaded|Uploading|Failed/ }).first()
-    ).toBeVisible()
-
-    await expect(
-      page.locator('button, div').filter({ hasText: /Public|Private/ }).first()
-    ).toBeVisible()
-
-    await expect(page.getByRole('button', { name: 'Delete' }).first()).toBeVisible()
-  })
-
-  test('download — triggers download on first card', async ({ page }) => {
-    await page.goto('/mydatasets')
-    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
-
-    await page.getByRole('button', { name: 'Download' }).first().click()
-
-    await expect(page.locator('.toast')).toContainText(/Download/)
-  })
-
-  test.skip('upload — uploads a test dataset then deletes it', async ({ page, browserName }) => {
-    // Playwright 在 Linux 上自带的 WebKit 不支持 OPFS（navigator.storage.getDirectory），
-    // 上传流程依赖 OPFS 压缩，故在 webkit 跳过。chromium / firefox 正常覆盖。
-    test.skip(browserName === 'webkit', 'Linux WebKit 不支持 OPFS')
-
-    // 含 cvParam 的 imzML，客户端自动解析填掉 7 个字段
-    const imzml = `<?xml version="1.0" encoding="utf-8"?>
-<mzML xmlns="http://psi.hupo.org/ms/mzml" version="1.1">
-  <cvList><cv id="MS" fullName="PSI-MS" version="4.1.7"/></cvList>
-  <fileDescription><fileContent>
-    <cvParam accession="MS:1000127" name="centroid spectrum" value=""/>
-    <cvParam accession="IMS:1000030" name="continuous" value=""/>
-  </fileContent></fileDescription>
-  <referenceableParamGroupList>
-    <referenceableParamGroup id="common">
-      <cvParam accession="MS:1000130" name="positive scan" value=""/>
-      <cvParam accession="MS:1000075" name="MALDI" value=""/>
-      <cvParam accession="MS:1000084" name="TOF" value=""/>
-      <cvParam name="pixel size x" value="50"/>
-      <cvParam name="pixel size y" value="50"/>
-    </referenceableParamGroup>
-  </referenceableParamGroupList>
-  <run id="test" defaultInstrumentConfigurationRef="IC1">
-    <spectrumList count="0"/>
-  </run>
-</mzML>`
-
-    // 创建临时文件，测试结束后从磁盘清理
-    const dir = mkdtempSync(join(tmpdir(), 'mv-upload-'))
-    writeFileSync(join(dir, 'test_lyk_upload.imzML'), imzml)
-    writeFileSync(join(dir, 'test_lyk_upload.ibd'), randomBytes(1024))
-
-    try {
-      // ── 上传 ──
-      await page.goto('/mydatasets')
-      await page.getByRole('button', { name: 'Upload New Dataset' }).click()
-      await expect(page.getByText('Upload New Dataset (imzML + ibd)')).toBeVisible()
-
-      await page.locator('input[type="file"]').setInputFiles([
-        join(dir, 'test_lyk_upload.imzML'),
-        join(dir, 'test_lyk_upload.ibd'),
-      ])
-
-      // 等文件解析完成
-      await page.waitForTimeout(2000)
-      await expect(page.locator('#is_public')).not.toBeChecked()
-
-      // Vue SelectWithOther 不响应 selectOption，用点击 + 键盘选择（限 modal 内）
-      const pickLabels = ['Organism', 'Organism Part', 'Condition', 'Sample Stabilization']
-      for (const label of pickLabels) {
-        const area = page.locator('.modal-box').locator(`label:has-text("${label}")`).first().locator('..')
-        await area.locator('select').click()
-        await page.keyboard.press('ArrowDown')
-        await page.keyboard.press('Enter')
-        await page.waitForTimeout(300)
-      }
-
-      // SolventPicker：选溶剂 → 填百分比 → 按 Enter 添加
-      const solventArea = page.locator('.modal-box').locator('label:has-text("Solvent")').locator('..')
-      await solventArea.locator('select').click()
-      await page.keyboard.press('ArrowDown')
-      await page.keyboard.press('Enter')
-      await page.waitForTimeout(300)
-      await solventArea.getByPlaceholder('e.g. 50').fill('50')
-      await solventArea.getByPlaceholder('e.g. 50').press('Enter')
-
-      await page.getByRole('button', { name: 'Confirm & Upload' }).click()
-
-      // 等上传完成 → 弹窗关闭 → 列表刷新
-      await expect(page.locator('.toast')).toContainText(/success|reused|complete/, { timeout: 120_000 })
-      await expect(page.getByText('Upload New Dataset (imzML + ibd)')).not.toBeVisible()
-
-      // ── 删除刚才上传的数据集 ──
-      // 轮询 Refresh Status 直到 Uploading 消失（最长 1 分钟）
-      await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
-      const deadline = Date.now() + 60_000
-      while (Date.now() < deadline) {
-        await page.getByRole('button', { name: 'Refresh Status' }).click()
-        await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
-        if (await page.locator('text=Uploading').count() === 0) break
-        await page.waitForTimeout(5000)
-      }
-      await expect(page.locator('text=Uploading')).toHaveCount(0)
-
-      // 删列表中第一个
-      await page.getByRole('button', { name: 'Delete' }).first().click()
-      await expect(page.getByText('Are you sure you want to delete this dataset?')).toBeVisible()
-
-      // 确认删除（限 modal-box 内，避免 backdrop close 按钮拦截）
-      await page.locator('.modal-box').getByRole('button', { name: 'Delete' }).click()
-      await expect(page.locator('.toast')).toContainText(/deleted/)
-    } finally {
-      try { rmSync(dir, { recursive: true }) } catch { /* ok */ }
+    const eligible: number[] = []
+    for (let i = 0; i < count; i++) {
+      const card = downloadBtns.nth(i).locator('..').locator('..')
+      const sizeText = await card.locator('p:has-text("File Size:")').innerText()
+      if (sizeToMB(sizeText) < MAX_DOWNLOAD_MB) eligible.push(i)
     }
+    const pick = eligible.length > 0
+      ? eligible[Math.floor(Math.random() * eligible.length)]
+      : 0
+
+    const cardName = await downloadBtns.nth(pick).locator('..').locator('..')
+      .locator('h3').innerText()
+    await expect(downloadBtns.nth(pick).locator('..').locator('..').locator('h3')).not.toBeEmpty()
+
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      downloadBtns.nth(pick).click(),
+    ])
+
+    const filename = download.suggestedFilename()
+    expect(filename).toContain(cardName!.replace('Dataset name: ', ''))
+
+    // 清理下载文件（WebKit 偶发超时，忽略）
+    try { await download.delete() } catch { /* ok */ }
+  })
+
+  test('download rate limit — second download is blocked', async ({ page }) => {
+    await page.goto('/datasets')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    const btns = page.locator('button').filter({ hasText: /Download/ })
+    const count = await btns.count()
+    const idx1 = Math.floor(Math.random() * count)
+    let idx2: number
+    if (count > 1) {
+      do { idx2 = Math.floor(Math.random() * count) } while (idx2 === idx1)
+    } else {
+      idx2 = idx1
+    }
+
+    await btns.nth(idx1).click()
+    await expect(page.locator('.toast')).toContainText('Download started')
+    await page.waitForTimeout(2000)
+
+    await btns.nth(idx2).click()
+    await expect(page.locator('.toast')).toContainText(/Download is limited/)
+    await page.waitForTimeout(1000)
   })
 })

--- a/e2e/new-analysis.spec.ts
+++ b/e2e/new-analysis.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * NewAnalysis E2E 测试 — 真实后端
+ * ================================
+ * 创建分析页面 /workspace/new
+ *
+ * 依赖：用户已登录且有至少一个 dataset
+ */
+
+test.describe('New Analysis', () => {
+
+  test('page loads with Step 1, Step 2 visible and Step 3 hidden', async ({ page }) => {
+    await page.goto('/workspace/new')
+
+    await expect(page.locator('h1:has-text("Create New Analysis")')).toBeVisible()
+    await expect(page.getByText('Step 1: Data Source')).toBeVisible()
+    await expect(page.getByText('Step 2: Preprocessing Pipeline')).toBeVisible()
+
+    // Step 3 已隐藏
+    await expect(page.getByText('Step 3: Annotation Settings')).not.toBeVisible()
+  })
+
+  test('summary panel shows disabled state when no dataset selected', async ({ page }) => {
+    await page.goto('/workspace/new')
+
+    await expect(page.getByText('Analysis Summary')).toBeVisible()
+    await expect(page.getByText('No dataset selected')).toBeVisible()
+
+    const startBtn = page.getByRole('button', { name: 'Start Analysis' })
+    await expect(startBtn).toBeDisabled()
+
+    await expect(page.getByText('Select dataset and configure pipeline first')).toBeVisible()
+  })
+
+  test('switching dataset updates summary panel', async ({ page }) => {
+    await page.goto('/workspace/new')
+    await page.locator('.tab:has-text("My Datasets")').click()
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    // 至少需要 2 个数据集
+    const radios = page.locator('input[name="selectedDataset"]')
+    const count = await radios.count()
+    if (count < 2) {
+      test.skip(true, `Only ${count} dataset(s), need ≥ 2 to test switching`)
+      return
+    }
+
+    // 选第一个
+    const firstLi = radios.first().locator('..')
+    const firstName = await firstLi.locator('.font-medium').innerText()
+    await firstLi.click()
+    await expect(firstLi.locator('input[type="radio"]')).toBeChecked()
+
+    // Summary 显示第一个名称
+    const summarySection = page.locator('.lg\\:col-span-1')
+    await expect(summarySection.getByText(firstName!.trim())).toBeVisible()
+
+    // 换选第二个
+    const secondLi = radios.nth(1).locator('..')
+    const secondName = await secondLi.locator('.font-medium').innerText()
+    await secondLi.click()
+
+    // 第二个 radio 选中，第一个取消
+    await expect(secondLi.locator('input[type="radio"]')).toBeChecked()
+    await expect(firstLi.locator('input[type="radio"]')).not.toBeChecked()
+
+    // Summary 更新为第二个名称
+    await expect(summarySection.getByText(secondName!.trim())).toBeVisible()
+    await expect(summarySection.getByText(firstName!.trim())).not.toBeVisible()
+  })
+
+  test('selecting a dataset updates summary panel', async ({ page }) => {
+    await page.goto('/workspace/new')
+
+    // 切换到 My Datasets tab
+    await page.locator('.tab:has-text("My Datasets")').click()
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    // 取第一个数据集的名称，通过 radio 所在的 li 定位
+    const firstLi = page.locator('input[name="selectedDataset"]').first().locator('..')
+    const nameEl = firstLi.locator('.font-medium')
+    const datasetName = await nameEl.innerText()
+    await expect(nameEl).not.toBeEmpty()
+
+    // 点击数据集行
+    await firstLi.click()
+
+    // radio 变为选中
+    await expect(firstLi.locator('input[type="radio"]')).toBeChecked()
+
+    // Summary panel 不再显示 "No dataset selected"
+    await expect(page.getByText('No dataset selected')).not.toBeVisible()
+
+    // Summary panel 的 "Selected dataset" 区域显示该名称
+    const summarySection = page.locator('.lg\\:col-span-1')
+    await expect(summarySection.getByText(datasetName!.trim())).toBeVisible()
+
+    // Dataset metadata 区域出现（自动回填了 MS 设置）
+    await expect(page.getByText('Dataset metadata')).toBeVisible()
+  })
+
+  test('selecting a preprocessing method enables submit', async ({ page }) => {
+    await page.goto('/workspace/new')
+    await page.locator('.tab:has-text("My Datasets")').click()
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    // 先选数据集（通过 radio input 定位）
+    const radios = page.locator('input[name="selectedDataset"]')
+    await radios.first().waitFor({ state: 'visible', timeout: 10_000 })
+    const count = await radios.count()
+    const pick = count > 1 ? Math.floor(Math.random() * count) : 0
+    await radios.nth(pick).locator('..').click()
+
+    // Start Analysis 仍然 disabled（没选 method）
+    await expect(page.getByRole('button', { name: 'Start Analysis' })).toBeDisabled()
+
+    // 点击最后一个预处理方法（Peak Alignment）
+    const methodLabels = page.locator('details[open] label')
+    const lastMethodLabel = methodLabels.nth(await methodLabels.count() - 1)
+    await lastMethodLabel.click()
+
+    // 方法选中后按钮应变为可用
+    await expect(page.getByRole('button', { name: 'Start Analysis' })).toBeEnabled()
+    await expect(page.getByText('Select dataset and configure pipeline first')).not.toBeVisible()
+  })
+
+  test('submit, wait for completion, then delete', async ({ page }) => {
+    test.setTimeout(180_000)
+    await page.goto('/workspace/new')
+    await page.locator('.tab:has-text("My Datasets")').click()
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+
+    const radios = page.locator('input[name="selectedDataset"]')
+    await radios.first().waitFor({ state: 'visible', timeout: 10_000 })
+    const count = await radios.count()
+    const pick = count > 1 ? Math.floor(Math.random() * count) : 0
+    await radios.nth(pick).locator('..').click()
+
+    const methodLabels = page.locator('details[open] label')
+    await methodLabels.nth(await methodLabels.count() - 1).click()
+
+    await page.getByRole('button', { name: 'Start Analysis' }).click()
+
+    await expect(page).toHaveURL(/\/workspace(?:\?|#|$)?/, { timeout: 30_000 })
+    await expect(page.locator('h1:has-text("Workspace")')).toBeVisible()
+
+    // 等刚创建的进程出现在表格里（状态为 Running）
+    const runningRow = page.locator('table tr').filter({ hasText: 'Running' }).first()
+    await expect(runningRow).toBeVisible({ timeout: 15_000 })
+
+    // 轮询刷新，等到 Running 消失，最多 2 分钟
+    const deadline = Date.now() + 120_000
+    while (Date.now() < deadline) {
+      await page.reload()
+      await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+      // 等表格数据真正加载完（不再是 "Loading..."）
+      await expect(page.locator('table tbody tr').first().locator('td').first())
+        .not.toHaveText('Loading...', { timeout: 15_000 })
+      const hasRunning = (await page.locator('table')
+        .getByText('Running')
+        .count()) > 0
+      if (!hasRunning) break
+      await page.waitForTimeout(10_000)
+    }
+    await expect(page.locator('table').getByText('Running')).not.toBeVisible()
+
+    // 关掉可能挡住的弹窗（CreateTaskModal / ErrorModal）
+    const openModal = page.locator('dialog.modal-open')
+    if (await openModal.isVisible().catch(() => false)) {
+      await openModal.getByRole('button').first().click()
+    }
+
+    await page.locator('table tbody tr').first()
+      .getByRole('button', { name: 'Delete' })
+      .click()
+
+    await page.locator('.modal-box').getByRole('button', { name: 'Delete' }).click()
+    await expect(page.locator('.toast')).toContainText('Result deleted', { timeout: 10_000 })
+  })
+})
+
+// ============================================================
+// Workspace
+// ============================================================
+
+test.describe('Workspace', () => {
+
+  test('page loads with summary cards and recent results', async ({ page }) => {
+    await page.goto('/workspace')
+
+    await expect(page.locator('h1:has-text("Workspace")')).toBeVisible()
+
+    // 三张 SummaryCard（通过唯一副标题区分）
+    await expect(page.getByText('Active preprocessing tasks')).toBeVisible()
+    await expect(page.getByText('Successfully completed')).toBeVisible()
+    await expect(page.getByText('Requires review')).toBeVisible()
+
+    // Recent Results 区块
+    await expect(page.getByText('Recent Results')).toBeVisible()
+  })
+
+  test('New Task — navigates to create analysis page', async ({ page }) => {
+    await page.goto('/workspace')
+
+    await page.getByRole('link', { name: 'New Task' }).click()
+
+    await expect(page).toHaveURL(/\/workspace\/new/)
+    await expect(page.locator('h1:has-text("Create New Analysis")')).toBeVisible()
+  })
+
+  test('Go to MyDatasets — navigates to my datasets page', async ({ page }) => {
+    await page.goto('/workspace')
+
+    await page.getByRole('link', { name: 'Go to MyDatasets' }).click()
+
+    await expect(page).toHaveURL(/\/mydatasets/)
+    await expect(page.locator('h1:has-text("My Datasets")')).toBeVisible()
+  })
+})

--- a/e2e/result-detail.spec.ts
+++ b/e2e/result-detail.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Result Detail E2E 测试 — 真实后端
+ * ================================
+ * 结果详情页 /workspace/results
+ *
+ * 依赖：workspace 中有至少一个已完成的进程
+ */
+
+/** 用真实鼠标点击 ECharts 谱图 canvas */
+async function clickSpectrum(page: Page) {
+  // 从 Average Spectrum 标题找到谱图容器
+  const heading = page.getByText('Average Spectrum')
+  // 结构：h3 → div → div.header → div.root → .overflow-hidden
+  const chart = heading.locator('..').locator('..').locator('..').locator('.overflow-hidden')
+
+  const box = await chart.boundingBox()
+  if (!box) throw new Error('Spectrum chart bounding box not found')
+
+  // grid.left=64，点中心偏右
+  await page.mouse.click(box.x + box.width * 0.6, box.y + box.height * 0.4)
+}
+
+test.describe('Result Detail', () => {
+
+  test('shows stale state when accessed directly', async ({ page }) => {
+    await page.goto('/workspace/results')
+    await expect(page.getByText('No result selected')).toBeVisible()
+  })
+
+  test('loads ion image, spectrum, metadata, and responds to click', async ({ page }) => {
+    await page.goto('/workspace')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+    await expect(page.locator('table tbody tr').first().locator('td').first())
+      .not.toHaveText('Loading...', { timeout: 15_000 })
+
+    const completedRow = page.locator('table tr').filter({ hasText: 'Completed' }).first()
+    await expect(completedRow).toBeVisible({ timeout: 10_000 })
+
+    await completedRow.getByRole('button', { name: 'View' }).click()
+    await expect(page).toHaveURL(/\/workspace\/results/)
+
+    // header
+    await expect(page.locator('h1')).not.toBeEmpty()
+    await expect(page.getByText('completed')).toBeVisible()
+
+    // ion image + spectrum 加载完成
+    await expect(page.getByText('Loading ion image...')).not.toBeVisible({ timeout: 30_000 })
+    await expect(page.getByText('Loading average spectrum...')).not.toBeVisible({ timeout: 30_000 })
+
+    // 平均谱图
+    await expect(page.getByText('Average Spectrum')).toBeVisible()
+    await expect(page.getByText(/peaks/)).toBeVisible()
+
+    // 右侧 ColorBar 元数据
+    await expect(page.getByText('Polarity')).toBeVisible()
+    await expect(page.getByText('Analyzer')).toBeVisible()
+    await expect(page.getByText('Ionisation Source')).toBeVisible()
+
+    // 用真实鼠标点击谱图选 m/z
+    await page.waitForTimeout(1000)
+    await clickSpectrum(page)
+    await page.waitForTimeout(1000)
+    // 等 ion image 响应（如果有变化会重新加载）
+    await expect(page.getByText('Loading ion image...')).not.toBeVisible()
+    await page.waitForTimeout(1000)
+
+    // 确认点击后页面没崩：谱图在、ion image 没退到 Loading
+    await expect(page.getByText('Average Spectrum')).toBeVisible()
+    await expect(page.getByText('Loading ion image...')).not.toBeVisible()
+  })
+
+  test('switches colormap and keeps ion image stable', async ({ page }) => {
+    await page.goto('/workspace')
+    await expect(page.locator('.animate-pulse')).toHaveCount(0, { timeout: 15_000 })
+    await expect(page.locator('table tbody tr').first().locator('td').first())
+      .not.toHaveText('Loading...', { timeout: 15_000 })
+
+    const completedRow = page.locator('table tr').filter({ hasText: 'Completed' }).first()
+    await expect(completedRow).toBeVisible({ timeout: 10_000 })
+    await completedRow.getByRole('button', { name: 'View' }).click()
+    await expect(page).toHaveURL(/\/workspace\/results/)
+
+    await expect(page.getByText('Loading ion image...')).not.toBeVisible({ timeout: 30_000 })
+
+    // 切换到 Viridis
+    const colormapSelect = page.locator('select').first()
+    await colormapSelect.selectOption('viridis')
+    await page.waitForTimeout(500)
+
+    // ion image 没崩
+    await expect(page.getByText('Loading ion image...')).not.toBeVisible()
+  })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,8 @@ import { defineConfig, devices } from '@playwright/test'
  */
 export default defineConfig({
   testDir: './e2e',
+  /* 排除 new-analysis 测试，暂时不运行 */
+  testIgnore: ['**/new-analysis.spec.ts'],
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
   expect: {
@@ -26,7 +28,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,6 @@
 {
   "appName": "SpatialXomics",
+  "version": "0.0.1",
   "hero": {
     "taglines": ["OPEN ↗", "FAST ▶︎▶︎", "UNIFIED ≡", "INTELLIGENT ✧"],
     "gallery": [

--- a/src/app/components/Navbar.vue
+++ b/src/app/components/Navbar.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/features/auth/stores/authStore'
@@ -42,4 +42,15 @@ onMounted(() => {
     authStore.fetchUser().catch(() => {})
   }
 })
+
+// Auto-open sidebar after fresh login redirect
+watch(
+  () => router.currentRoute.value.path,
+  (path) => {
+    if (sessionStorage.getItem('just_logged_in')) {
+      sidebarOpen.value = true
+      sessionStorage.removeItem('just_logged_in')
+    }
+  },
+)
 </script>

--- a/src/features/auth/components/LoginForm.vue
+++ b/src/features/auth/components/LoginForm.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
       placeholder="Password"
     />
 
-    <div v-if="false" class="text-right -mt-4">
+    <div class="text-right -mt-4">
       <router-link
         to="/forgotpassword"
         class="link link-hover text-xs text-base-content/70"

--- a/src/features/auth/composables/useForgotPassword.ts
+++ b/src/features/auth/composables/useForgotPassword.ts
@@ -141,7 +141,7 @@ export function useForgotPassword() {
 
     loading.sendCode = true
     try {
-      await sendEmailCode(form.email, 'update')
+      await sendEmailCode(form.email, 'reset_password')
       showToast('Verification code sent! Check your email.', 'success')
       startCountdown()
       step.value = 'reset'

--- a/src/features/auth/composables/useLoginForm.ts
+++ b/src/features/auth/composables/useLoginForm.ts
@@ -38,9 +38,10 @@ export function useLoginForm() {
       if (!access_token) throw new Error('Invalid token received')
 
       authStore.login(access_token)
+      sessionStorage.setItem('just_logged_in', '1')
       showToast('Login successful! Redirecting...', 'success')
       setTimeout(() => {
-        router.push('/profile').catch((err) => console.error('Router Push Error:', err))
+        router.push('/mydatasets').catch((err) => console.error('Router Push Error:', err))
       }, 800)
     } catch (error: any) {
       console.error('Login Error:', error)

--- a/src/features/datasets/api/datasetApi.ts
+++ b/src/features/datasets/api/datasetApi.ts
@@ -1,4 +1,4 @@
-import { auth_api } from '@/shared/api/httpClient'
+import { auth_api, api } from '@/shared/api/httpClient'
 import { getConfig } from '@/shared/config/runtimeConfig'
 
 // 约定：本模块所有函数都返回**解包后的响应体**（res.data），调用方不再处理 axios 信封。
@@ -10,8 +10,9 @@ export async function getDownloadMetadata(fileId: string) {
 }
 
 // GET /files/{file_id}/metadata — 根据文件 ID 获取元数据
-export async function getFileMetadata(fileId: string | number) {
-  const res = await auth_api.get(`/files/${fileId}/metadata`)
+export async function getFileMetadata(fileId: string | number, isPublic = false) {
+  const client = isPublic ? api : auth_api
+  const res = await client.get(`/files/${fileId}/metadata`)
   return res.data
 }
 
@@ -26,8 +27,9 @@ export interface DownloadRawResponse {
   files: DownloadRawEntry[]
 }
 
-export async function getDownloadRaw(fileId: string): Promise<DownloadRawResponse> {
-  const res = await auth_api.get(`/files/${fileId}/download_raw`)
+export async function getDownloadRaw(fileId: string, isPublic = false): Promise<DownloadRawResponse> {
+  const client = isPublic ? api : auth_api
+  const res = await client.get(`/files/${fileId}/download_raw`)
   return res.data
 }
 
@@ -51,8 +53,9 @@ export function pickImageUrl(images: FileImagesResponse): string {
   return fallback
 }
 
-export async function getFileImages(fileId: string | number): Promise<FileImagesResponse> {
-  const res = await auth_api.get(`/files/${fileId}/images`)
+export async function getFileImages(fileId: string | number, isPublic = false): Promise<FileImagesResponse> {
+  const client = isPublic ? api : auth_api
+  const res = await client.get(`/files/${fileId}/images`)
   return res.data
 }
 
@@ -62,10 +65,17 @@ export async function deleteFile(fileId: string | number) {
   return res.data
 }
 
+// PUT /files/{file_id}/set_public
+export async function setFilePublic(fileId: string | number) {
+  const res = await auth_api.put(`/files/${fileId}/set_public`)
+  return res.data
+}
+
 // POST /files/list_files?page={page}&size={size}
 // Backend expects a JSON body of filter attributes; returns { data: [...], meta: {...} }.
-export async function listFiles(filters: Record<string, any> = {}, page = 1, size = getConfig().pagination.defaultPageSize) {
-  const res = await auth_api.post('/files/list_files', filters, { params: { page, size } })
+export async function listFiles(filters: Record<string, any> = {}, page = 1, size = getConfig().pagination.defaultPageSize, isPublic = false) {
+  const client = isPublic ? api : auth_api
+  const res = await client.post('/files/list_files', filters, { params: { page, size } })
   return res.data
 }
 
@@ -98,7 +108,6 @@ export async function getUserQuota(): Promise<UserQuota> {
 export async function createProcess(payload: {
   file_id: number
   algorithms: Record<string, any>
-  is_public?: boolean
 }) {
   const res = await auth_api.post('/processes', payload)
   return res.data

--- a/src/features/datasets/composables/useDatasetDetail.ts
+++ b/src/features/datasets/composables/useDatasetDetail.ts
@@ -1,15 +1,18 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { getFileMetadata, getFileImages, pickImageUrl } from '@/features/datasets/api/datasetApi'
+import axios from 'axios'
+import { getFileMetadata, getFileImages, pickImageUrl, setFilePublic } from '@/features/datasets/api/datasetApi'
 import { mapItemToDataset } from '@/features/datasets/mappers/datasetMapper'
 import type { File } from '@/features/datasets/types/dataset'
 import { useDownloadProgress } from '@/features/datasets/composables/useDownloadProgress'
 import { getDatasetPlaceholderSvg } from '@/features/datasets/utils/datasetPlaceholder'
 import { formatBytes } from '@/shared/utils/format'
+import { useToast } from '@/shared/composables/useToast'
 
 export function useDatasetDetail() {
   const router = useRouter()
   const { handleDownloadRaw, isPacking } = useDownloadProgress()
+  const { showToast } = useToast()
 
   // 从 history.state 读取导航上下文（无路径参数，刷新后会丢失）
   const state = history.state as { fileId?: string; source?: 'my' | 'public' } | null
@@ -22,6 +25,7 @@ export function useDatasetDetail() {
   const ticImageError = ref(false)
 
   const source = computed(() => state?.source || 'my')
+  const isPublic = computed(() => source.value === 'public')
   /** 刷新后 history.state 丢失，此时应提示用户从列表页重新进入 */
   const isStale = computed(() => !state?.fileId)
 
@@ -70,7 +74,43 @@ export function useDatasetDetail() {
         if (!filename) return undefined
         return filename.toLowerCase().endsWith('.zip') ? filename : `${filename}.zip`
       },
+      isPublic: isPublic.value,  // 公开页面不需要登录
     })
+  }
+
+  // Make Public
+  const makingPublic = ref(false)
+  const showPublicConfirm = ref(false)
+
+  const openPublicConfirm = () => {
+    showPublicConfirm.value = true
+  }
+
+  const cancelPublicConfirm = () => {
+    showPublicConfirm.value = false
+  }
+
+  const confirmSetPublic = async () => {
+    const targetId = dataset.value?.id ? String(dataset.value.id) : ''
+    if (!targetId) return
+    makingPublic.value = true
+    try {
+      await setFilePublic(targetId)
+      // 直接更新本地状态，避免刷新页面
+      if (dataset.value) {
+        dataset.value.isPublic = true
+      }
+      showToast('Dataset is now public.', 'success')
+    } catch (error) {
+      const message = axios.isAxiosError(error)
+        ? (error.response?.data?.message || error.message)
+        : 'Failed to make dataset public'
+      showToast(message, 'error')
+      console.error('Failed to set file public', error)
+    } finally {
+      makingPublic.value = false
+      showPublicConfirm.value = false
+    }
   }
 
   const fetchDatasetDetails = async () => {
@@ -82,13 +122,13 @@ export function useDatasetDetail() {
 
     loading.value = true
     try {
-      const metadata = await getFileMetadata(fileId)
+      const metadata = await getFileMetadata(fileId, isPublic.value)
       dataset.value = metadata ? mapItemToDataset(metadata) : null
       // Fetch TIC image after dataset is loaded
       if (dataset.value?.id) {
         try {
           ticImageError.value = false
-          const images = await getFileImages(dataset.value.id)
+          const images = await getFileImages(dataset.value.id, isPublic.value)
           ticImageUrl.value = pickImageUrl(images)
         } catch {
           ticImageUrl.value = ''
@@ -122,5 +162,10 @@ export function useDatasetDetail() {
     downloadCurrent,
     isPacking,
     fetchDatasetDetails,
+    makingPublic,
+    showPublicConfirm,
+    openPublicConfirm,
+    cancelPublicConfirm,
+    confirmSetPublic,
   }
 }

--- a/src/features/datasets/composables/useDatasetListRouteState.ts
+++ b/src/features/datasets/composables/useDatasetListRouteState.ts
@@ -1,5 +1,4 @@
 import { onMounted, type Ref } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
 import type { useAuthStore } from '@/features/auth/stores/authStore'
 
 type FetchFiles = (opts?: { page?: number; size?: number }) => Promise<void>
@@ -18,24 +17,12 @@ interface DatasetRouteStateOptions {
 }
 
 export function useDatasetListRouteState(options: DatasetRouteStateOptions) {
-  // External composables
-  const route = useRoute()
-  const router = useRouter()
-
   // Methods
   const fetchCurrentPage = () =>
     options.fetchFiles({ page: options.page.value, size: options.size.value })
 
-  const replaceQuery = (query: Record<string, string>) => {
-    router.replace({ query: { ...route.query, ...query } })
-  }
-
   const initializeFromRoute = () => {
-    const qp = Number(route.query.page || 1)
-    const qs = Number(route.query.size || options.size.value)
-    options.page.value = qp > 0 ? qp : 1
-    options.size.value = qs > 0 ? qs : options.size.value
-
+    // 不再从 URL 读取分页参数，始终从第一页开始
     const load = () => options.fetchFiles({ page: options.page.value, size: options.size.value })
     if (!options.auth.user && options.auth.token) {
       options.auth.fetchUser().finally(load)
@@ -48,7 +35,6 @@ export function useDatasetListRouteState(options: DatasetRouteStateOptions) {
   const applyAndRefresh = (payload: Record<string, any>) => {
     options.applyFilters(payload)
     options.page.value = 1
-    replaceQuery({ page: '1' })
     fetchCurrentPage()
   }
 
@@ -69,14 +55,12 @@ export function useDatasetListRouteState(options: DatasetRouteStateOptions) {
     const normalizedPage = Math.min(Math.max(nextPage, 1), totalPages)
     options.page.value = normalizedPage
     options.meta.current_page = normalizedPage
-    replaceQuery({ page: String(normalizedPage) })
     options.goToPage(normalizedPage)
   }
 
   const changeSize = (newSize: number) => {
     options.size.value = newSize
     options.page.value = 1
-    replaceQuery({ page: '1', size: String(newSize) })
     options.changeSize(newSize)
   }
 

--- a/src/features/datasets/composables/useDownloadProgress.ts
+++ b/src/features/datasets/composables/useDownloadProgress.ts
@@ -42,12 +42,12 @@ export function useDownloadProgress() {
    */
   const handleDownloadRaw = async (
     id?: string,
-    options?: { getFallbackFilename?: () => string | undefined },
+    options?: { getFallbackFilename?: () => string | undefined, isPublic?: boolean },
   ) => {
     if (!id) return
     if (packingIds.has(id)) return
 
-    // Rate-limit check
+    // Rate-limit check（登录和未登录都限制，防止刷带宽）
     if (!downloadStore.canDownload()) {
       const remain = Math.ceil(downloadStore.cooldownRemaining())
       showToast(
@@ -61,7 +61,7 @@ export function useDownloadProgress() {
     downloadStore.startDownload(id)
     const toastId = showToast('Downloading...', 'info', 0)
     try {
-      await ossDownloadRaw(id, options)
+      await ossDownloadRaw(id, { ...options, isPublic: options?.isPublic ?? false })
       downloadStore.completeDownload()
       removeToast(toastId)
       showToast('Download started', 'success')

--- a/src/features/datasets/utils/downloadHelper.ts
+++ b/src/features/datasets/utils/downloadHelper.ts
@@ -57,9 +57,9 @@ export async function ossDownloadAndSave(
  */
 export async function ossDownloadRaw(
   fileId: string,
-  options?: { getFallbackFilename?: () => string | undefined },
+  options?: { getFallbackFilename?: () => string | undefined, isPublic?: boolean },
 ) {
-  const { files } = await getDownloadRaw(fileId)
+  const { files } = await getDownloadRaw(fileId, options?.isPublic ?? false)
 
   if (!files || !files.length) {
     throw new Error('No download URLs returned')

--- a/src/features/home/components/FooterScene.vue
+++ b/src/features/home/components/FooterScene.vue
@@ -57,7 +57,10 @@ const poweredBy = [
           </a>
         </template>
       </nav>
-      <p>Copyright © {{ year }} - All rights reserved by Bionet</p>
+      <p class="flex items-center justify-center gap-2">
+        <span>Copyright © {{ year }} - All rights reserved by Bionet</span>
+        <span v-if="config.version" class="badge badge-outline badge-sm border-base-content/30 text-base-content/60">v{{ config.version }}</span>
+      </p>
     </footer>
   </BaseScene>
 </template>

--- a/src/features/upload/components/UploadFilePicker.vue
+++ b/src/features/upload/components/UploadFilePicker.vue
@@ -52,7 +52,6 @@ const onFileChange = (event: Event) => {
   <label class="form-control w-full shrink-0">
     <div class="label">
       <span class="label-text">Select an .imzML and .ibd file pair</span>
-      <span class="label-text-alt text-error" v-if="error">{{ error }}</span>
     </div>
     <div
       class="relative flex items-center justify-between border border-base-content/20 rounded-lg px-3 py-2 bg-base-100 hover:bg-base-200/50 transition-colors overflow-hidden min-h-12"
@@ -93,6 +92,9 @@ const onFileChange = (event: Event) => {
         >Ready: <span class="break-all">{{ selectedPair.baseName }}</span> ({{ formattedSize }})</span
       >
       <span v-else class="text-base-content/60">No matched pair selected</span>
+    </div>
+    <div v-if="error" class="border border-error/30 bg-error/5 text-error rounded-lg px-4 py-3 mt-3 text-base break-all">
+      <span>{{ error }}</span>
     </div>
   </label>
 </template>

--- a/src/features/upload/composables/useUploadResume.ts
+++ b/src/features/upload/composables/useUploadResume.ts
@@ -17,6 +17,9 @@ export function useUploadResume() {
       pendingResume.value = true
       const session = loadUploadSession()
       pendingDatasetName.value = session?.datasetName || ''
+    } else {
+      // No pending session — clean up any orphaned ZIP from a previous abort
+      cleanupResumable()
     }
   }
 

--- a/src/features/upload/utils/imzmlCompress.ts
+++ b/src/features/upload/utils/imzmlCompress.ts
@@ -21,8 +21,6 @@ export interface CompressProgressEvent {
 export interface CompressOptions {
   onProgress?: (e: CompressProgressEvent) => void
   signal?: AbortSignal
-  /** Generate ZIP entry names from the file hash, e.g. { imzmlName, ibdName } */
-  getEntryNames?: (hash: string) => { imzmlName: string; ibdName: string }
 }
 
 export interface CompressResult {
@@ -31,16 +29,46 @@ export interface CompressResult {
 }
 
 /**
- * Compress imzML + ibd into a ZIP stored in OPFS.
- *
- * Two-phase worker protocol:
- * 1. Worker hashes imzml+ibd → sends hash → parent generates entry names
- * 2. Worker compresses with renamed entries → sends done
+ * Full pipeline: hash → compress (for resume or when hash is not needed early).
+ * Kept for backward compatibility with resume flow.
  */
 export async function compressImzmlToOPFS(
   pair: ImzmlFilePair,
-  options?: CompressOptions,
+  options?: CompressOptions & { getEntryNames?: (hash: string) => { imzmlName: string; ibdName: string } },
 ): Promise<CompressResult> {
+  const { fileHash, startCompress } = await prepareUpload(pair, options)
+  const names = options?.getEntryNames?.(fileHash) ?? {
+    imzmlName: pair.imzml.name,
+    ibdName: pair.ibd.name,
+  }
+  const file = await startCompress(names)
+  return { file, fileHash }
+}
+
+// ────────────────────────────────────────────────────────────
+// Two-phase upload preparation
+// ────────────────────────────────────────────────────────────
+
+export interface UploadPreparation {
+  fileHash: string
+  /** Call after preflight to continue with compression. Skip if preflight returned reuse. */
+  startCompress: (
+    entryNames: { imzmlName: string; ibdName: string },
+    onProgress?: (e: CompressProgressEvent) => void,
+  ) => Promise<File>
+}
+
+/**
+ * Phase 1: start the worker, wait for hash, then pause before compression.
+ * Returns the hash immediately so the caller can preflight.
+ *
+ * Call `startCompress(entryNames)` to resume compression.
+ * If you never call it (e.g. preflight reuse), the worker is terminated automatically.
+ */
+export function prepareUpload(
+  pair: ImzmlFilePair,
+  options?: CompressOptions,
+): Promise<UploadPreparation> {
   if (options?.signal?.aborted) {
     throw new DOMException('Aborted by user', 'AbortError')
   }
@@ -78,60 +106,116 @@ export async function compressImzmlToOPFS(
       const msg = e.data
 
       switch (msg.type) {
-        case 'progress':
-          if (options?.onProgress) {
-            // Reset speed tracker on phase transition so it doesn't bleed
-            if (lastPhase && msg.phase !== lastPhase) {
-              tracker.reset()
-              lastReportTime = 0
-            }
-            lastPhase = msg.phase
-            const now = Date.now()
-            if (now - lastReportTime > 100) {
-              const { speedStr, etaStr } = tracker.update(msg.loaded, totalBytes)
-              options.onProgress({
-                loadedBytes: msg.loaded,
-                totalBytes,
-                percent: Math.min(100, Math.round((msg.loaded / totalBytes) * 100)),
-                phase: msg.phase,
-                speedStr,
-                etaStr,
-              })
-              lastReportTime = now
-            }
+        case 'progress': {
+          if (!options?.onProgress) break
+          if (lastPhase && msg.phase !== lastPhase) {
+            tracker.reset()
+            lastReportTime = 0
+          }
+          lastPhase = msg.phase
+          const now = Date.now()
+          if (now - lastReportTime > 100) {
+            const { speedStr, etaStr } = tracker.update(msg.loaded, totalBytes)
+            options.onProgress({
+              loadedBytes: msg.loaded,
+              totalBytes,
+              percent: Math.min(100, Math.round((msg.loaded / totalBytes) * 100)),
+              phase: msg.phase,
+              speedStr,
+              etaStr,
+            })
+            lastReportTime = now
           }
           break
+        }
 
         case 'hash-ready': {
-          const hash: string = msg.hash
-          const names = options?.getEntryNames?.(hash) ?? {
-            imzmlName: pair.imzml.name,
-            ibdName: pair.ibd.name,
-          }
-          worker.postMessage({ type: 'rename', ...names })
+          // Hash is ready — expose it to the caller, defer compression
+          const fileHash: string = msg.hash
+
+          resolve({
+            fileHash,
+            startCompress: (entryNames, onProgress) => {
+              return new Promise<File>((res, rej) => {
+                const fail = (err: Error) => {
+                  cleanup()
+                  rej(err)
+                }
+
+                // Listen for abort during compression
+                if (options?.signal) {
+                  if (options.signal.aborted) {
+                    fail(new DOMException('Aborted by user', 'AbortError'))
+                    return
+                  }
+                  options.signal.addEventListener('abort', () => fail(new DOMException('Aborted by user', 'AbortError')), { once: true })
+                }
+
+                worker.onerror = () => fail(new Error('Zip compression worker failed'))
+
+                worker.onmessage = (ev: MessageEvent) => {
+                  const m = ev.data
+
+                  if (m.type === 'progress' && onProgress) {
+                    if (lastPhase && m.phase !== lastPhase) {
+                      tracker.reset()
+                      lastReportTime = 0
+                    }
+                    lastPhase = m.phase
+                    const now = Date.now()
+                    if (now - lastReportTime > 100) {
+                      const { speedStr, etaStr } = tracker.update(m.loaded, totalBytes)
+                      onProgress({
+                        loadedBytes: m.loaded,
+                        totalBytes,
+                        percent: Math.min(100, Math.round((m.loaded / totalBytes) * 100)),
+                        phase: m.phase,
+                        speedStr,
+                        etaStr,
+                      })
+                      lastReportTime = now
+                    }
+                    return
+                  }
+
+                  if (m.type === 'done') {
+                    cleanup()
+                    loadZipFromOPFS()
+                      .then((file) => {
+                        if (!file) {
+                          rej(new Error('Compressed file not found in OPFS'))
+                          return
+                        }
+                        if (options?.onProgress) {
+                          options.onProgress({
+                            loadedBytes: totalBytes,
+                            totalBytes,
+                            percent: 100,
+                            speedStr: '',
+                            etaStr: '',
+                          })
+                        }
+                        res(file)
+                      })
+                      .catch(rej)
+                    return
+                  }
+
+                  if (m.type === 'error') {
+                    fail(new Error(m.message))
+                    return
+                  }
+                }
+
+                worker.postMessage({ type: 'rename', ...entryNames })
+              })
+            },
+          })
           break
         }
 
         case 'done':
-          cleanup()
-          loadZipFromOPFS()
-            .then((file) => {
-              if (!file) {
-                reject(new Error('Compressed file not found in OPFS'))
-                return
-              }
-              if (options?.onProgress) {
-                options.onProgress({
-                  loadedBytes: totalBytes,
-                  totalBytes,
-                  percent: 100,
-                  speedStr: '',
-                  etaStr: '',
-                })
-              }
-              resolve({ file, fileHash: msg.hash })
-            })
-            .catch(reject)
+          // Shouldn't reach here in two-phase mode (handled in startCompress)
           break
 
         case 'error':
@@ -146,7 +230,7 @@ export async function compressImzmlToOPFS(
       reject(new Error('Zip compression worker failed'))
     }
 
-    // Phase 1: send files to worker for hashing (no entry names yet)
+    // Start Phase 1: hash
     worker.postMessage({
       type: 'start',
       imzml: pair.imzml,

--- a/src/features/upload/utils/imzmlOssUpload.ts
+++ b/src/features/upload/utils/imzmlOssUpload.ts
@@ -1,6 +1,6 @@
 import OSS from 'ali-oss'
 import { ProgressTracker, type ImzmlFilePair, type UnifiedUploadProgress } from './imzmlHelper'
-import { compressImzmlToOPFS } from './imzmlCompress'
+import { prepareUpload, type UploadPreparation } from './imzmlCompress'
 import { auth_api } from '@/shared/api/httpClient'
 import {
   saveUploadSession,
@@ -58,10 +58,12 @@ export interface UploadImzmlOssConfig {
 /**
  * OSS-based imzML upload pipeline.
  *
- * Phase 1-2: ZIP + hash (reused from imzml-helper).
- * Phase 3a: Preflight with storage_type=oss → file_id.
- * Phase 3b: POST /files/upload with pre_file_id + filename → OSS STS credentials + fc_request_id.
- * Phase 4:   Upload directly to OSS with callback notification.
+ * Phase 1: Hash via Worker → generate filename (pauses before compression).
+ * Phase 2: Preflight with original size + hash → file_id.
+ *   If reuse: return immediately (no compression / upload needed).
+ * Phase 3: Compress to ZIP in OPFS (continue Worker).
+ * Phase 4: POST /files/upload with pre_file_id → OSS STS credentials.
+ * Phase 5: Upload directly to OSS with callback notification.
  */
 export async function uploadImzmlZipFileOSS({
   files,
@@ -80,6 +82,7 @@ export async function uploadImzmlZipFileOSS({
   let fileId: string
   let ossData: OssUploadResponse
   let normalizedFilename: string
+  let prep: UploadPreparation | null = null
 
   if (resume) {
     // ---------- Resume path: restore from OPFS + localStorage ----------
@@ -113,43 +116,31 @@ export async function uploadImzmlZipFileOSS({
     }
     onProgress?.({ stage: 'uploading', percent: 0, message: 'Resuming upload...' })
   } else {
-    // ---------- Normal path: pack → hash → preflight ----------
+    // ==================== Normal path ====================
     if (!files) throw new Error('No files provided for upload')
 
-    // ================= Check storage quota =================
-    await checkStorageQuota(files)
-
-    // ================= Phase 1: Compress + Hash =================
-    onProgress?.({ stage: 'packing', percent: 0, message: 'Building dataset archive...' })
-    const { file: zipFileFromOPFS, fileHash: hash } = await compressImzmlToOPFS(files, {
+    // -----------------------------------------------------------
+    // Phase 1: Hash via Worker (pauses before compression)
+    // -----------------------------------------------------------
+    onProgress?.({ stage: 'preflight', percent: 0, message: 'Preparing upload...' })
+    prep = await prepareUpload(files, {
       signal,
       onProgress: (p) =>
-        onProgress?.({
-          stage: 'packing',
-          percent: p.percent,
-          message: p.phase === 'hashing'
-            ? `Preparing ${p.percent.toFixed(1)}%`
-            : `Compressing ${p.percent.toFixed(1)}%`,
-          speedStr: p.speedStr,
-          etaStr: p.etaStr,
-        }),
-      getEntryNames: (fileHash) => {
-        const name = generateDatasetFilename(metadata, fileHash)
-        return { imzmlName: `${name}.imzML`, ibdName: `${name}.ibd` }
-      },
+        onProgress?.({ stage: 'preflight', percent: p.percent, message: 'Preparing upload...' }),
     })
-    zipFile = zipFileFromOPFS
-    fileHash = hash
+    fileHash = prep.fileHash
 
     // Generate filename: {organism}_{part}_{source}_{pixelX}_{polarity}_{hash6}
     normalizedFilename = generateDatasetFilename(metadata, fileHash)
 
-    // ================= Phase 2: Preflight =================
-    onProgress?.({ stage: 'preflight', percent: 100, message: 'Requesting upload token...' })
+    // -----------------------------------------------------------
+    // Phase 2: Preflight (before compression — reuse avoids compress cost)
+    // -----------------------------------------------------------
+    onProgress?.({ stage: 'preflight', percent: 100, message: 'Checking server for existing file...' })
 
     const preflightPayload = {
       filename: normalizedFilename,
-      size: zipFile.size,
+      size: files.ibd.size + files.imzml.size,
       file_verify_code: fileHash,
       is_public: metadata.is_public ?? false,
       total_parts: 1,
@@ -164,20 +155,43 @@ export async function uploadImzmlZipFileOSS({
       throw new Error('Preflight did not return file_id')
     }
 
-    // ================= Phase 3a: Reuse short-circuit =================
-    // Backend signals that this file already exists on its side (matched by hash etc.),
-    // so we skip the OSS credential fetch + actual upload entirely.
+    // ── Reuse short-circuit: file already on server ──
     if (preflightData.is_reuse) {
       onProgress?.({
         stage: 'completed',
         percent: 100,
         message: 'File already exists on server, reused.',
       })
-      await cleanupResumable()
+      // prep.startCompress was never called → Worker gets GC'd
       return { upload_id: String(fileId), fileHash, oss_path: '', reused: true, datasetName: normalizedFilename }
     }
 
-    // ================= Phase 3b: Get OSS credentials =================
+    // -----------------------------------------------------------
+    // Phase 3: Compress (only if not reused)
+    // -----------------------------------------------------------
+    await checkStorageQuota(files)
+
+    onProgress?.({ stage: 'packing', percent: 0, message: 'Building dataset archive...' })
+    zipFile = await prep.startCompress(
+      {
+        imzmlName: `${normalizedFilename}.imzML`,
+        ibdName: `${normalizedFilename}.ibd`,
+      },
+      (p) =>
+        onProgress?.({
+          stage: 'packing',
+          percent: p.percent,
+          message: p.phase === 'hashing'
+            ? `Preparing ${p.percent.toFixed(1)}%`
+            : `Compressing ${p.percent.toFixed(1)}%`,
+          speedStr: p.speedStr,
+          etaStr: p.etaStr,
+        }),
+    )
+
+    // -----------------------------------------------------------
+    // Phase 4: Get OSS credentials
+    // -----------------------------------------------------------
     onProgress?.({ stage: 'preflight', percent: 100, message: 'Fetching upload credentials...' })
 
     const uploadPayload = new URLSearchParams({
@@ -192,7 +206,7 @@ export async function uploadImzmlZipFileOSS({
     }
   }
 
-  // ================= Phase 4: OSS Upload =================
+  // ================= Phase 5: OSS Upload =================
   onProgress?.({ stage: 'uploading', percent: 0, message: 'Uploading to server...' })
 
   const region = `oss-${ossData.oss_region_id}`

--- a/src/features/upload/utils/quotaCheck.ts
+++ b/src/features/upload/utils/quotaCheck.ts
@@ -15,8 +15,8 @@ export async function checkStorageQuota(pair: ImzmlFilePair): Promise<void> {
     const estMB = (estimated / 1048576).toFixed(0)
     const availMB = (available / 1048576).toFixed(0)
     throw new Error(
-      `Insufficient storage: estimated ${estMB} MB needed, but only ${availMB} MB available. ` +
-        `Please free up disk space or use a smaller dataset.`,
+      `Insufficient browser storage: this upload needs ~${estMB} MB, but only ${availMB} MB is available in your browser's temporary storage. ` +
+        `Please close other tabs, clear browser cache, or use a smaller dataset.`,
     )
   }
 }

--- a/src/features/workspace/analysis/components/AnalysisSummaryPanel.vue
+++ b/src/features/workspace/analysis/components/AnalysisSummaryPanel.vue
@@ -8,13 +8,11 @@ defineProps<{
   selectedDataset: any
   estimateTimeDisplay: string
   quotaStorage: string
-  isPublic: boolean
   canSubmit: boolean
   submitting: boolean
 }>()
 
 const emit = defineEmits<{
-  (e: 'update:isPublic', value: boolean): void
   (e: 'submit'): void
 }>()
 </script>
@@ -84,24 +82,6 @@ const emit = defineEmits<{
               <span class="text-base-content font-medium">{{ quotaStorage }}</span>
             </div>
           </div>
-        </div>
-
-        <!-- TODO: Visibility 功能暂未启用，先隐藏 UI，后端 isPublic 字段保留 -->
-        <div v-if="false" class="border-t border-base-200/70 px-5 py-4">
-          <label class="flex items-center justify-between cursor-pointer">
-            <div>
-              <div class="text-lg font-medium text-base-content/60">Visibility</div>
-              <div class="text-base text-base-content/40 mt-0.5">
-                {{ isPublic ? 'Public' : 'Private' }}
-              </div>
-            </div>
-            <input
-              type="checkbox"
-              class="toggle toggle-sm"
-              :checked="isPublic"
-              @change="emit('update:isPublic', ($event.target as HTMLInputElement).checked)"
-            />
-          </label>
         </div>
 
         <div class="border-t border-base-200/70 px-5 py-4">

--- a/src/features/workspace/analysis/components/DataSourceStep.vue
+++ b/src/features/workspace/analysis/components/DataSourceStep.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts">
 import UploadModal from '@/features/upload/components/UploadModal.vue'
+import PaginationBar from '@/shared/components/PaginationBar.vue'
 import { formatBytes } from '@/shared/utils/format'
 
-defineProps<{
+const props = defineProps<{
   activeTab: 'upload' | 'my'
   uploadOpen: boolean
   datasetQuery: string
   loading: boolean
   error: string
-  filteredDatasets: any[]
+  datasets: any[]
   selectedDataset: any
+  meta: Record<string, any>
+  page: number
+  size: number
+  pagination: (number | string)[]
 }>()
 
 const emit = defineEmits<{
@@ -19,6 +24,9 @@ const emit = defineEmits<{
   (e: 'upload-success'): void
   (e: 'upload-close'): void
   (e: 'select-dataset', dataset: any): void
+  (e: 'go-to-page', page: number): void
+  (e: 'prev-page'): void
+  (e: 'next-page'): void
 }>()
 </script>
 
@@ -50,13 +58,30 @@ const emit = defineEmits<{
     </div>
 
     <div v-if="activeTab === 'my'">
-      <div class="mb-2">
+      <div class="flex items-center gap-3 mb-2">
         <input
           :value="datasetQuery"
           @input="emit('update:datasetQuery', ($event.target as HTMLInputElement).value)"
-          placeholder="Search datasets"
-          class="input input-bordered w-full"
+          placeholder="Search..."
+          class="input input-bordered w-48"
         />
+        <div v-if="meta.total_pages > 0" class="flex items-center gap-3 ml-auto">
+          <span class="text-base text-base-content/60 whitespace-nowrap tabular-nums"
+            >Page {{ meta.current_page }} / {{ meta.total_pages }} &mdash;
+            {{ meta.total_records }} records</span
+          >
+          <PaginationBar
+            :current-page="meta.current_page"
+            :total-pages="meta.total_pages"
+            :total-items="meta.total_records"
+            :from="(meta.current_page - 1) * size + 1"
+            :to="Math.min(meta.current_page * size, meta.total_records)"
+            :page-range="pagination"
+            @prev-page="emit('prev-page')"
+            @next-page="emit('next-page')"
+            @go-to-page="(p) => emit('go-to-page', p)"
+          />
+        </div>
       </div>
       <div class="max-h-48 overflow-auto border border-base-200 bg-base-100 rounded-md p-2">
         <div v-if="loading" class="flex items-center justify-center p-4">
@@ -66,7 +91,7 @@ const emit = defineEmits<{
           <div v-if="error" class="text-lg text-error p-3">{{ error }}</div>
           <ul>
             <li
-              v-for="dataset in filteredDatasets"
+              v-for="dataset in datasets"
               :key="dataset.id"
               :class="[
                 'px-4 py-2 cursor-pointer flex items-center justify-between',
@@ -92,7 +117,7 @@ const emit = defineEmits<{
               />
             </li>
           </ul>
-          <div v-if="filteredDatasets.length === 0" class="text-lg text-base-content/60 p-3">
+          <div v-if="datasets.length === 0" class="text-lg text-base-content/60 p-3">
             No datasets found.
           </div>
         </div>

--- a/src/features/workspace/analysis/composables/useAnalysisBuilder.ts
+++ b/src/features/workspace/analysis/composables/useAnalysisBuilder.ts
@@ -47,7 +47,6 @@ export function useAnalysisBuilder(
     pixelSize: false,
   })
 
-  const isPublic = ref(false)
   const quota = ref<UserQuota | null>(null)
   const quotaLoading = ref(false)
   const submitting = ref(false)
@@ -265,7 +264,6 @@ export function useAnalysisBuilder(
         selectedMethods,
         methodParams,
         methodGroups: allMethodGroups,
-        isPublic: isPublic.value,
       })
       await createProcess(payload)
       showToast('Analysis started', 'success')
@@ -295,7 +293,6 @@ export function useAnalysisBuilder(
     selectedMethods,
     methodParams,
     analysisForm,
-    isPublic,
     quota,
     quotaLoading,
     quotaStorage,

--- a/src/features/workspace/analysis/composables/useAnalysisDatasets.ts
+++ b/src/features/workspace/analysis/composables/useAnalysisDatasets.ts
@@ -1,12 +1,22 @@
-import { computed, onMounted, ref, watch } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 import { listUserFiles } from '@/features/datasets/api/datasetApi'
 import { useDatasetList } from '@/features/datasets/composables/useDatasetList'
 
 export function useAnalysisDatasets() {
-  // External composables
-  const { datasets, loading, error, fetchFiles } = useDatasetList((filters, page, size) =>
-    listUserFiles(filters, page, size),
-  )
+  // External composables — fully leverage useDatasetList's pagination
+  const {
+    datasets,
+    loading,
+    error,
+    fetchFiles,
+    meta,
+    page,
+    size,
+    pagination,
+    goToPage,
+    changeSize,
+    applyFilters,
+  } = useDatasetList((filters, page, size) => listUserFiles(filters, page, size))
 
   // State
   const activeTab = ref<'upload' | 'my'>('my')
@@ -14,20 +24,13 @@ export function useAnalysisDatasets() {
   const selectedDataset = ref<any>(null)
   const uploadOpen = ref(false)
 
-  // Computed
-  const filteredDatasets = computed(() => {
-    const query = datasetQuery.value.trim().toLowerCase()
-    if (!query) return datasets.value
-    return datasets.value.filter((dataset) => (dataset.name || '').toLowerCase().includes(query))
-  })
-
   // Methods
   const selectDataset = (dataset: any) => {
     selectedDataset.value = dataset
   }
 
   const onUploadSuccess = async () => {
-    await fetchFiles({ page: 1, size: 50 })
+    await fetchFiles()
     const newest = datasets.value[0]
     if (newest) selectedDataset.value = newest
     uploadOpen.value = false
@@ -42,9 +45,20 @@ export function useAnalysisDatasets() {
     if (value === 'upload') uploadOpen.value = true
   })
 
+  // Debounced server-side search — reset to page 1 on every query change
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  watch(datasetQuery, (query) => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      const trimmed = query.trim()
+      applyFilters(trimmed ? { name: trimmed } : {})
+      fetchFiles({ page: 1, size: size.value })
+    }, 300)
+  })
+
   // Lifecycle
   onMounted(() => {
-    fetchFiles({ page: 1, size: 100 }).catch(() => {})
+    fetchFiles().catch(() => {})
   })
 
   return {
@@ -55,7 +69,12 @@ export function useAnalysisDatasets() {
     datasets,
     loading,
     error,
-    filteredDatasets,
+    meta,
+    page,
+    size,
+    pagination,
+    goToPage,
+    changeSize,
     fetchFiles,
     selectDataset,
     onUploadSuccess,

--- a/src/features/workspace/analysis/services/buildProcessPayload.ts
+++ b/src/features/workspace/analysis/services/buildProcessPayload.ts
@@ -5,7 +5,6 @@ interface BuildProcessPayloadOptions {
   selectedMethods: Record<string, string>
   methodParams: Record<string, string | number>
   methodGroups: any[]
-  isPublic: boolean
 }
 
 const BACKEND_ALGORITHM_KEYS: Record<string, string> = {
@@ -84,6 +83,5 @@ export function buildProcessPayload(options: BuildProcessPayloadOptions) {
   return {
     file_id: Number(options.selectedDataset?.id) ?? 0,
     algorithms,
-    is_public: options.isPublic,
   }
 }

--- a/src/features/workspace/dashboard/components/WorkspaceTable.vue
+++ b/src/features/workspace/dashboard/components/WorkspaceTable.vue
@@ -113,7 +113,18 @@ const openRow = (r: any) => {
     emit('view-error', r.errorMessage || 'Unknown error')
     return
   }
-  router.push({ name: 'WorkspaceResultDetail', state: { runId: r.id } })
+  router.push({
+    name: 'WorkspaceResultDetail',
+    state: {
+      runId: r.id,
+      processName: r.name,
+      datasetName: r.dataset,
+      filename: r.filename,
+      fileId: r.fileId,
+      methods: r.methods,
+      status: r.status,
+    },
+  })
 }
 </script>
 

--- a/src/features/workspace/dashboard/composables/useWorkspaceDashboard.ts
+++ b/src/features/workspace/dashboard/composables/useWorkspaceDashboard.ts
@@ -20,6 +20,8 @@ export interface TaskRow {
   id: string
   name: string
   dataset: string
+  filename: string
+  fileId: number
   methods: string[]
   status: string
   created: string
@@ -46,6 +48,8 @@ export function useWorkspaceDashboard() {
       id: String(p.id),
       name: `Process #${p.id}`,
       dataset: getFileName(p),
+      filename: p.filename || '',
+      fileId: p.source_file_id,
       methods: parseAlgorithms(p.params_json),
       status: p.status,
       created: parseUtcDate(p.finished_at || p.created_at)?.toLocaleString() ?? '',

--- a/src/features/workspace/results/components/IonImageSection.vue
+++ b/src/features/workspace/results/components/IonImageSection.vue
@@ -12,6 +12,7 @@ defineProps<{
   mzTolerance: number
   colormap: string
   intensityScale: string
+  gamma: number
   displayMin: number
   displayMax: number
   dataMax: number
@@ -70,6 +71,7 @@ watch(roiOverlayRef, (el) => emit('roi-overlay-ref', el ?? null))
           :mz-tolerance="mzTolerance"
           :colormap="colormap"
           :intensity-scale="intensityScale"
+          :gamma="gamma"
           :display-min="displayMin"
           :display-max="displayMax"
           :matrix="displayMatrix"

--- a/src/features/workspace/results/components/OverlayControls.vue
+++ b/src/features/workspace/results/components/OverlayControls.vue
@@ -10,6 +10,7 @@ defineProps<{
   draftReady: boolean
   viewingRoi: boolean
   confirmedRois: any[]
+  gamma: number
 }>()
 
 const emit = defineEmits<{
@@ -21,12 +22,35 @@ const emit = defineEmits<{
   (e: 'roi-delete', id: string): void
   (e: 'roi-clear-all'): void
   (e: 'roi-reset'): void
+  (e: 'update:gamma', value: number): void
 }>()
 </script>
 
 <template>
   <div class="mt-3 pt-3 border-t border-base-200">
-    <div class="text-base font-semibold text-base-content/50 mb-2">Statistical Visualization</div>
+    <div class="text-base font-semibold text-base-content/50 mb-2">Visualization</div>
+
+    <div class="mb-3">
+      <div class="flex items-center justify-between mb-1">
+        <span class="text-sm text-base-content/50">Gamma</span>
+        <span class="text-sm font-mono text-base-content/60">{{ gamma.toFixed(1) }}</span>
+      </div>
+      <input
+        type="range"
+        class="range range-xs range-primary"
+        min="0.5"
+        max="1.5"
+        step="0.1"
+        :value="gamma"
+        @input="emit('update:gamma', +($event.target as HTMLInputElement).value)"
+      />
+      <div class="flex justify-between text-xs text-base-content/40 mt-0.5">
+        <span>0.5</span>
+        <span>1.0</span>
+        <span>1.5</span>
+      </div>
+    </div>
+
     <div class="flex gap-2">
       <button
         class="btn btn-sm flex-1 text-base rounded-lg transition-colors"

--- a/src/features/workspace/results/components/visuals/AverageSpectrum.vue
+++ b/src/features/workspace/results/components/visuals/AverageSpectrum.vue
@@ -111,7 +111,7 @@ function buildSelectorGraphic(): unknown[] {
   const gridRect = gridModel?.coordinateSystem?.getRect?.()
   const topY = gridRect ? gridRect.y : 24
   const bottomY = gridRect ? gridRect.y + gridRect.height : 200
-  const label = mz.toFixed(4)
+  const label = mz
 
   return [
     {
@@ -187,8 +187,8 @@ function renderChart() {
           if (!items?.length) return ''
           const [mz, intensity] = items[0]!.data
           return `<div class="font-mono text-xs">
-            <div>m/z: <strong>${mz.toFixed(4)}</strong></div>
-            <div>Mean intensity: <strong>${intensity.toFixed(4)}</strong></div>
+            <div>m/z: <strong>${mz}</strong></div>
+            <div>Mean intensity: <strong>${intensity}</strong></div>
           </div>`
         },
       },
@@ -196,7 +196,7 @@ function renderChart() {
       xAxis: {
         type: 'value', name: 'm/z', scale: true,
         nameLocation: 'center', nameGap: 28,
-        axisLabel: { formatter: (v: number) => v.toFixed(4) },
+        axisLabel: {},
         axisPointer: { label: { show: false } },
         nameTextStyle: { fontSize: 15, color: '#6b7280' },
         axisLine: { lineStyle: { color: '#9ca3af' } },

--- a/src/features/workspace/results/components/visuals/ColorBar.vue
+++ b/src/features/workspace/results/components/visuals/ColorBar.vue
@@ -35,7 +35,7 @@
     <div class="mt-3 pt-3 border-t border-base-200">
       <div class="text-base font-semibold text-base-content/50 mb-2">Statistic</div>
       <div class="rounded-lg border border-base-200 bg-base-200/50 p-3 space-y-2">
-        <div class="relative h-20 rounded border border-base-200 bg-base-200 overflow-hidden">
+        <div class="relative h-20 rounded border border-base-200 bg-base-200 overflow-visible -mx-3">
           <canvas ref="histCanvasRef" class="absolute inset-0 w-full h-full" />
           <div
             class="absolute top-0 bottom-0 w-[2px] bg-red-500/80 z-10"
@@ -122,12 +122,12 @@ const localMin = computed(() => props.displayMin)
 const localMax = computed(() => props.displayMax)
 const range = computed(() => props.globalMax - props.globalMin || 1)
 function markerLeft(v: number) {
-  return ((v - props.globalMin) / range.value) * 100
+  return Math.max(0, Math.min(100, ((v - props.globalMin) / range.value) * 100))
 }
 
 function pctLabel(v: number): string {
   const arr = props.sortedValues
-  if (!arr.length) return '0.0%'
+  if (!arr.length) return '0.00%'
   let lo = 0,
     hi = arr.length
   while (lo < hi) {
@@ -135,7 +135,9 @@ function pctLabel(v: number): string {
     if (arr[mid]! <= v) lo = mid + 1
     else hi = mid
   }
-  return ((lo / arr.length) * 100).toFixed(1) + '%'
+  let pct = (lo / arr.length) * 100
+  if (lo < arr.length) pct = Math.min(pct, 99.99)
+  return pct.toFixed(2) + '%'
 }
 
 const statisticRows = computed(() => {

--- a/src/features/workspace/results/components/visuals/IonImageViewer.vue
+++ b/src/features/workspace/results/components/visuals/IonImageViewer.vue
@@ -81,6 +81,7 @@ const props = defineProps({
   mzTolerance: { type: Number, required: true },
   colormap: { type: String, required: true },
   intensityScale: { type: String, required: true },
+  gamma: { type: Number, default: 1 },
   displayMin: { type: Number, default: undefined },
   displayMax: { type: Number, default: undefined },
   matrix: { type: Object as PropType<Float32Array | null>, default: null },
@@ -126,6 +127,7 @@ const { scheduleRender, observeContainer } = useCanvasRenderer({
   matrixRows: computed(() => props.matrixRows),
   colormap: computed(() => props.colormap),
   intensityScale: computed(() => props.intensityScale),
+  gamma: computed(() => props.gamma),
   displayMin: computed(() => props.displayMin),
   displayMax: computed(() => props.displayMax),
   overlayData: computed(() => props.overlayData),
@@ -193,6 +195,7 @@ watch(
   () => [
     props.colormap,
     props.intensityScale,
+    props.gamma,
     props.matrix,
     props.selectedMz,
     props.displayMin,

--- a/src/features/workspace/results/composables/useCanvasRenderer.ts
+++ b/src/features/workspace/results/composables/useCanvasRenderer.ts
@@ -10,6 +10,7 @@ interface CanvasRendererOptions {
   matrixRows: Ref<number>
   colormap: Ref<string>
   intensityScale: Ref<string>
+  gamma: Ref<number>
   displayMin: Ref<number | undefined>
   displayMax: Ref<number | undefined>
   overlayData: Ref<Uint8ClampedArray | null>
@@ -76,6 +77,8 @@ export function useCanvasRenderer(
     const lut = buildLUT(opts.colormap.value)
     const useLog = opts.intensityScale.value === 'log'
 
+    const gamma = opts.gamma.value
+
     // 4% padding on each side so the image doesn't touch container edges
     const pad = 0.04
     const availW = W * (1 - pad * 2)
@@ -112,7 +115,7 @@ export function useCanvasRenderer(
         if (rawVal === 0) continue
 
         let norm = (rawVal - dispMin) / range
-        norm = Math.pow(Math.max(0, norm), 0.45)
+        if (gamma !== 1) norm = Math.pow(Math.max(0, norm), gamma)
         if (useLog) norm = Math.log1p(norm * 9) / Math.log1p(9)
         norm = Math.max(0, Math.min(1, norm))
         const lutIdx = Math.round(norm * 255)

--- a/src/features/workspace/results/composables/useResultMeta.ts
+++ b/src/features/workspace/results/composables/useResultMeta.ts
@@ -1,6 +1,15 @@
 import { ref, watch, type Ref } from 'vue'
-import { listMyProcesses, listUserFiles } from '@/features/datasets/api/datasetApi'
-import { parseAlgorithms } from '@/features/workspace/utils/methodsNormalize'
+import { getFileMetadata } from '@/features/datasets/api/datasetApi'
+
+interface ResultDetailState {
+  runId?: string
+  processName?: string
+  datasetName?: string
+  filename?: string
+  fileId?: number
+  methods?: string[]
+  status?: string
+}
 
 export function useResultMeta(runId: Ref<string>) {
   const datasetName = ref('')
@@ -13,10 +22,6 @@ export function useResultMeta(runId: Ref<string>) {
   const status = ref('')
   const methods = ref<string[]>([])
   const loading = ref(false)
-
-  function extractBasename(filename: string): string {
-    return filename.replace(/\.[^.]+$/, '')
-  }
 
   function formatPixelSize(x?: number, y?: number): string {
     if (x != null && y != null) return `${x} × ${y} µm`
@@ -32,41 +37,35 @@ export function useResultMeta(runId: Ref<string>) {
     if (hasPeakAlignment) storageMode.value = 'continuous'
   }
 
-  async function fetchMeta(id: string) {
+  async function fetchMeta(_id: string) {
     loading.value = true
     try {
-      const result = await listMyProcesses(1, 100)
-      const processes = result.data || []
-      const process = processes.find((p: any) => String(p.id) === id)
+      const state = history.state as ResultDetailState | null
 
-      if (process) {
-        datasetName.value = extractBasename(process.filename || '')
-        status.value = (process.status || '').toLowerCase()
+      // Read process info directly from router state (passed by WorkspaceTable)
+      datasetName.value = state?.datasetName || ''
+      status.value = (state?.status || '').toLowerCase()
+      methods.value = state?.methods || []
 
-        if (process.params_json) {
-          methods.value = parseAlgorithms(process.params_json)
-        }
-
-        // Fetch file metadata for instrument params
-        if (process.filename) {
-          try {
-            const fileResult = await listUserFiles({ filename: process.filename }, 1, 1)
-            const file = fileResult?.data?.[0] || fileResult?.[0]
-            if (file) {
-              analyzer.value = file.analyzer || ''
-              ionSource.value = file.ionisation_source || ''
-              pixelSize.value = formatPixelSize(file.pixel_size_horizontal, file.pixel_size_vertical)
-              polarity.value = file.polarity || ''
-              spectrumMode.value = file.spectrum_mode || ''
-              storageMode.value = file.storage_mode || ''
-            }
-          } catch {
-            // file lookup is optional
+      // Fetch file metadata for instrument params
+      const fileId = state?.fileId
+      if (fileId != null) {
+        try {
+          const file = await getFileMetadata(fileId)
+          if (file) {
+            analyzer.value = file.analyzer || ''
+            ionSource.value = file.ionisation_source || ''
+            pixelSize.value = formatPixelSize(file.pixel_size_horizontal, file.pixel_size_vertical)
+            polarity.value = file.polarity || ''
+            spectrumMode.value = file.spectrum_mode || ''
+            storageMode.value = file.storage_mode || ''
           }
+        } catch {
+          // file lookup is optional
         }
-
-        applyProcessingAdjustments()
       }
+
+      applyProcessingAdjustments()
     } catch (e) {
       console.error('[useResultMeta] fetch failed:', e)
     } finally {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -28,7 +28,6 @@ const routes = [
     path: '/overview',
     name: 'DatasetOverview',
     component: () => import('../views/DatasetOverviewView.vue'),
-    meta: { requiresAuth: true },
   },
   {
     path: '/login',
@@ -103,7 +102,7 @@ router.beforeEach(async (to, from, next) => {
   // But allow it if coming from an auth-required page (token may be stale / backend down)
   const fromAuthRequired = from.matched.some((record) => record.meta.requiresAuth)
   if (loggedIn && !fromAuthRequired && ['/login', '/register', '/forgotpassword'].includes(to.path)) {
-    return next('/profile')
+    return next('/mydatasets')
   }
 
   // Redirect to login page if authentication is required but user is not logged in

--- a/src/shared/components/PaginationBar.vue
+++ b/src/shared/components/PaginationBar.vue
@@ -6,8 +6,8 @@
     >
       <div class="join">
         <button
-          class="join-item btn hover:bg-secondary/80 bg-base-100 h-[2em] min-h-[2em] px-[1em] text-[1em] text-base-content/70"
-          :disabled="currentPage === 1"
+          class="join-item btn hover:bg-secondary/80 bg-base-100 border-base-content/20 h-[2em] min-h-[2em] px-[1em] text-[1em] text-base-content/70"
+          :class="{ 'pointer-events-none opacity-50': currentPage === 1 }"
           @click="$emit('prev-page')"
         >
           Prev
@@ -15,7 +15,7 @@
         <template v-for="(p, idx) in pageRange" :key="`pg-${idx}`">
           <button
             v-if="p !== '...'"
-            class="join-item btn h-[2em] min-h-[2em] font-medium text-[1em] bg-base-100"
+            class="join-item btn h-[2em] min-h-[2em] font-medium text-[1em] bg-base-100 tabular-nums"
             :class="
               currentPage === p
                 ? 'bg-base-200/80 text-base-content'
@@ -28,8 +28,8 @@
           <span v-else class="join-item btn btn-disabled h-[2em] min-h-[2em] text-[1em]">...</span>
         </template>
         <button
-          class="join-item btn hover:bg-secondary/80 bg-base-100 text-base-content/70 h-[2em] min-h-[2em] px-[1em] text-[1em]"
-          :disabled="currentPage === totalPages"
+          class="join-item btn hover:bg-secondary/80 bg-base-100 border-base-content/20 text-base-content/70 h-[2em] min-h-[2em] px-[1em] text-[1em]"
+          :class="{ 'pointer-events-none opacity-50': currentPage === totalPages }"
           @click="$emit('next-page')"
         >
           Next
@@ -40,6 +40,8 @@
         <input
           v-model="jumpInput"
           type="number"
+          min="1"
+          :max="totalPages"
           class="join-item input  bg-base-100 h-[2em] min-h-[2em] w-[4em] text-center text-[1em] text-base-content"
           :placeholder="`${currentPage}`"
           @keydown.enter="handleJump"

--- a/src/shared/config/runtimeConfig.ts
+++ b/src/shared/config/runtimeConfig.ts
@@ -260,6 +260,8 @@ export interface GithubHeatmapConfig {
 export interface AppConfig {
   /** 应用名称 */
   appName: string
+  /** 应用版本号，如 "0.3.0" */
+  version?: string
   /** 首屏 Hero 区 */
   hero: {
     /** 轮播展示的标语（每行一句，可含符号，如 "FREE ∞"） */

--- a/src/views/DatasetOverviewView.vue
+++ b/src/views/DatasetOverviewView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useDatasetDetail } from '@/features/datasets/composables/useDatasetDetail'
+import ConfirmDialog from '@/shared/components/ConfirmDialog.vue'
 
 const {
   source,
@@ -16,6 +17,11 @@ const {
   goBack,
   downloadCurrent,
   isPacking,
+  makingPublic,
+  showPublicConfirm,
+  openPublicConfirm,
+  cancelPublicConfirm,
+  confirmSetPublic,
 } = useDatasetDetail()
 </script>
 
@@ -109,6 +115,14 @@ const {
                 {{ dataset.filename }}
               </h2>
               <div class="flex items-center gap-2 shrink-0">
+                <button
+                  v-if="source === 'my' && !dataset.isPublic"
+                  @click="openPublicConfirm"
+                  class="btn btn-sm btn-outline btn-warning"
+                >
+                  <svg-icon type="region" class="w-4 h-4" />
+                  Make Public
+                </button>
                 <button
                   @click="downloadCurrent"
                   class="btn btn-sm btn-primary"
@@ -386,6 +400,18 @@ const {
           </div>
         </div>
       </template>
+
+      <!-- Make Public Confirmation Dialog -->
+      <ConfirmDialog
+        :open="showPublicConfirm"
+        title="Make Dataset Public"
+        message="This dataset will be moved to Public Data and become visible to other users. This action cannot be undone."
+        confirm-label="Make Public"
+        :danger="true"
+        :loading="makingPublic"
+        @confirm="confirmSetPublic"
+        @cancel="cancelPublicConfirm"
+      />
     </div>
   </div>
 </template>

--- a/src/views/PublicDatasets.vue
+++ b/src/views/PublicDatasets.vue
@@ -13,7 +13,7 @@ import { createDefaultDatasetFilters } from '@/features/datasets/constants/datas
 const initialFilters = createDefaultDatasetFilters()
 
 const fetcher = async (f: Record<string, any>, p: number, s: number) => {
-  return await listFiles(f, p, s)
+  return await listFiles(f, p, s, true)  // isPublic = true，不需要登录
 }
 
 const {

--- a/src/views/workspace/NewAnalysis.vue
+++ b/src/views/workspace/NewAnalysis.vue
@@ -12,7 +12,13 @@ const {
   uploadOpen,
   loading,
   error,
-  filteredDatasets,
+  datasets,
+  meta,
+  page,
+  size,
+  pagination,
+  goToPage,
+  changeSize,
   selectDataset,
   onUploadSuccess,
   onUploadClose,
@@ -24,7 +30,6 @@ const {
   modeNotice,
   selectedMethods,
   methodParams,
-  isPublic,
   quotaStorage,
   submitting,
   canSubmit,
@@ -62,12 +67,19 @@ const {
           :upload-open="uploadOpen"
           :loading="loading"
           :error="error"
-          :filtered-datasets="filteredDatasets"
+          :datasets="datasets"
           :selected-dataset="selectedDataset"
+          :meta="meta"
+          :page="page"
+          :size="size"
+          :pagination="pagination"
           @open-upload="uploadOpen = true"
           @upload-success="onUploadSuccess"
           @upload-close="onUploadClose"
           @select-dataset="selectDataset"
+          @go-to-page="goToPage"
+          @prev-page="goToPage(page - 1)"
+          @next-page="goToPage(page + 1)"
         />
 
         <PreprocessingPipelineStep
@@ -92,7 +104,6 @@ const {
       </div>
 
       <AnalysisSummaryPanel
-        v-model:is-public="isPublic"
         :status-badge="statusBadge"
         :pipeline-summary="pipelineSummary"
         :ms-settings-list="msSettingsList"

--- a/src/views/workspace/ResultDetail.vue
+++ b/src/views/workspace/ResultDetail.vue
@@ -13,13 +13,24 @@ import { useResultROI } from '@/features/workspace/results/composables/useResult
 import { useResultMeta } from '@/features/workspace/results/composables/useResultMeta'
 import { ZARR_STORE } from '@/shared/config/defaults'
 
-const state = history.state as { runId?: string } | null
-const runId = computed(() => state?.runId || '')
-const isStale = computed(() => !state?.runId)
+interface ResultDetailState {
+  runId?: string
+  processName?: string
+  datasetName?: string
+  filename?: string
+  fileId?: number
+  methods?: string[]
+  status?: string
+}
+
+const state = history.state as ResultDetailState | null
+const runId = computed(() => state?.runId != null ? String(state.runId) : '')
+const isStale = computed(() => state?.runId == null)
 
 const { datasetName, analyzer, ionSource, pixelSize, polarity, spectrumMode, storageMode, status, methods } = useResultMeta(runId)
 const colormap = ref('inferno')
 const intensityScale = ref('linear')
+const gamma = ref(1)
 
 const zarr = useZarrIonImage()
 const {
@@ -96,6 +107,7 @@ const resetControls = () => {
   mzTolerance.value = ZARR_STORE.defaultMzTolerance
   colormap.value = 'inferno'
   intensityScale.value = 'linear'
+  gamma.value = 1
   resetRange()
 }
 
@@ -135,6 +147,7 @@ const onDisplayMaxChange = (value: number) => {
         :mz-tolerance="mzTolerance"
         :colormap="colormap"
         :intensity-scale="intensityScale"
+        :gamma="gamma"
         :display-min="displayMin"
         :display-max="displayMax"
         :data-max="dataMax"
@@ -195,6 +208,7 @@ const onDisplayMaxChange = (value: number) => {
             :draft-ready="draftReady"
             :viewing-roi="viewingROI"
             :confirmed-rois="confirmedROIs as any"
+            :gamma="gamma"
             @toggle-overlay="toggleOverlay"
             @update:roi-tool="roiSelectTool"
             @roi-confirm="roiConfirm"
@@ -202,6 +216,7 @@ const onDisplayMaxChange = (value: number) => {
             @roi-delete="roiDelete"
             @roi-clear-all="roiClearAll"
             @roi-reset="roiReset"
+            @update:gamma="gamma = $event"
           />
         </template>
       </ColorBar>


### PR DESCRIPTION
* feat(e2e): restructure datasets tests, fix auth credentials, and misc improvements

- Restructure datasets E2E: upload first, test with data, delete last
- Add random download, download rate limit, sort, filter, overview tests
- Fix auth credentials to use env vars (E2E_USERNAME/E2E_PASSWORD)
- Fix playwright/no-networkidle in auth.spec.ts
- Set workers to 1 in playwright config
- Hide forgot password link and step 3 annotation settings
- Fix RegisterAccountForm button type
- Fix WorkspaceTable status normalization
- Fix useResultMeta status mapping
- Update test.yml workflow

* feat(e2e): add new-analysis + workspace tests, download verification, and misc fixes

- Add new-analysis E2E tests: page load, form states, dataset selection, method enable/disable, submit with polling for completion and cleanup
- Add workspace E2E tests: page load with summary cards, nav links
- Enhance download tests: intercept actual download, verify filename matches card, random selection with 300MB size filter
- Fix download rate limit tests to click within same page session
- Fix random selection by waiting for buttons to render before counting
- Fix auth login redirect to /mydatasets, env var credentials
- Add null checks for env vars in auth setup
- Various component fixes and improvements

* fix(e2e): replace textContent() with innerText() to satisfy playwright lint rule

* fix(e2e): add eslint-disable for innerText() where text value is needed for computation

* fix(e2e): fix lint — use not.toBeEmpty() instead of toBeTruthy() for innerText assertions

* fix(e2e): update e2e test command to use Playwright directly and handle modal visibility in new-analysis tests

* chore(ci): restore full e2e test suite after verifying new-analysis fix

* test(e2e): limit CI to new-analysis spec, fix dataset delete test

* test(e2e): restore full test suite, add result-detail spec

* feat: add make-public feature + zarr visualization improvements

Add make-public feature:
- Add setFilePublic API endpoint
- Add Make Public button with confirmation dialog
- Use local state update instead of page refresh for better UX

Zarr ion image visualization enhancements:
- Add gamma correction slider (0.5-1.5) for image contrast
- Fix histogram boundary overflow issue
- Improve m/z value formatting for spectrum display
- Optimize color rendering pipeline

E2E test improvements:
- Fix WebKit download timeout issues
- Improve selector reliability for overview buttons
- Skip delete test on WebKit to avoid edge cases

Config updates:
- Exclude new-analysis.spec.ts from CI test run
- Remove unused visibility/analysis public flags

* feat: 支持公开数据集访问，更新相关API和组件以处理公开状态