### PR TITLE
Feature/zarr update (#61)

### DIFF
--- a/src/features/datasets/components/DatasetCard.vue
+++ b/src/features/datasets/components/DatasetCard.vue
@@ -105,6 +105,7 @@ const emit = defineEmits<{
   (e: 'view-overview', id: string): void
   (e: 'download', id: string): void
   (e: 'delete', id: string): void
+  (e: 'explore', id: string): void
 }>()
 
 const ticImageUrl = ref<string>('')
@@ -168,6 +169,15 @@ const actionItems = computed<ActionItem[]>(() => {
     })
 
   // Action buttons
+  // Explore — 所有卡片都有
+  items.push({
+    id: 'explore',
+    icon: 'search',
+    label: 'Explore',
+    colorClass: 'text-primary hover:text-primary-focus transition-colors',
+    onClick: () => emit('explore', props.dataset.id),
+  })
+
   items.push(
     {
       id: 'overview',

--- a/src/features/datasets/components/DatasetList.vue
+++ b/src/features/datasets/components/DatasetList.vue
@@ -17,7 +17,7 @@ const props = defineProps({
   packingIds: { type: Object as PropType<Set<string>>, required: false, default: () => new Set() },
 })
 
-const emit = defineEmits(['view-overview', 'download', 'delete', 'change-size', 'go-to-page'])
+const emit = defineEmits(['view-overview', 'download', 'delete', 'explore', 'change-size', 'go-to-page'])
 
 const onChangeSize = (v: number) => emit('change-size', v)
 const onGoToPage = (p: number) => emit('go-to-page', p)
@@ -67,6 +67,7 @@ const pageSizeOptions = getConfig().pagination.pageSizeOptions
           @view-overview="$emit('view-overview', $event)"
           @download="$emit('download', $event)"
           @delete="$emit('delete', $event)"
+          @explore="$emit('explore', $event)"
         />
       </div>
     </div>

--- a/src/features/workspace/analysis/components/DataSourceStep.vue
+++ b/src/features/workspace/analysis/components/DataSourceStep.vue
@@ -4,7 +4,7 @@ import PaginationBar from '@/shared/components/PaginationBar.vue'
 import { formatBytes } from '@/shared/utils/format'
 
 const props = defineProps<{
-  activeTab: 'upload' | 'my'
+  activeTab: 'upload' | 'my' | 'public'
   uploadOpen: boolean
   datasetQuery: string
   loading: boolean
@@ -18,7 +18,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: 'update:activeTab', value: 'upload' | 'my'): void
+  (e: 'update:activeTab', value: 'upload' | 'my' | 'public'): void
   (e: 'update:datasetQuery', value: string): void
   (e: 'open-upload'): void
   (e: 'upload-success'): void
@@ -44,6 +44,11 @@ const emit = defineEmits<{
         @click.prevent="emit('update:activeTab', 'my')"
         >My Datasets</a
       >
+      <a
+        :class="['tab', activeTab === 'public' ? 'tab-active' : '']"
+        @click.prevent="emit('update:activeTab', 'public')"
+        >Public Datasets</a
+      >
     </div>
 
     <div v-if="activeTab === 'upload'">
@@ -57,7 +62,7 @@ const emit = defineEmits<{
       />
     </div>
 
-    <div v-if="activeTab === 'my'">
+    <div v-if="activeTab === 'my' || activeTab === 'public'">
       <div class="flex items-center gap-3 mb-2">
         <input
           :value="datasetQuery"

--- a/src/features/workspace/analysis/components/PreprocessingPipelineStep.vue
+++ b/src/features/workspace/analysis/components/PreprocessingPipelineStep.vue
@@ -24,7 +24,7 @@ defineProps<{
 
     <div class="space-y-4 mt-2">
       <div
-        v-if="isFiltered"
+        v-if="modeNotice"
         class="flex items-start gap-2 p-3 rounded-md bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 text-lg text-blue-700 dark:text-blue-300"
       >
         <span class="mt-0.5">ℹ</span>

--- a/src/features/workspace/analysis/composables/useAnalysisBuilder.ts
+++ b/src/features/workspace/analysis/composables/useAnalysisBuilder.ts
@@ -23,12 +23,12 @@ export function useAnalysisBuilder(
   // State
   const spectrumMode = ref('')
   const storageMode = ref('')
+  const selectedMethods = reactive<Record<string, string>>({})
   const { availableMethods, isFiltered, modeNotice } = usePreprocessingMethods(
     spectrumMode,
     storageMode,
+    selectedMethods,
   )
-
-  const selectedMethods = reactive<Record<string, string>>({})
   // 默认参数由方法定义生成（单一数据源，见 buildDefaultMethodParams），不再在此硬编码
   const methodParams = reactive(buildDefaultMethodParams())
 

--- a/src/features/workspace/analysis/composables/useAnalysisDatasets.ts
+++ b/src/features/workspace/analysis/composables/useAnalysisDatasets.ts
@@ -1,28 +1,61 @@
-import { onMounted, ref, watch } from 'vue'
-import { listUserFiles } from '@/features/datasets/api/datasetApi'
+import { computed, onMounted, ref, watch } from 'vue'
+import { listUserFiles, listFiles } from '@/features/datasets/api/datasetApi'
 import { useDatasetList } from '@/features/datasets/composables/useDatasetList'
 
 export function useAnalysisDatasets() {
-  // External composables — fully leverage useDatasetList's pagination
+  // My Datasets
   const {
-    datasets,
-    loading,
-    error,
-    fetchFiles,
-    meta,
-    page,
-    size,
-    pagination,
-    goToPage,
-    changeSize,
-    applyFilters,
+    datasets: myDatasets,
+    loading: myLoading,
+    error: myError,
+    fetchFiles: fetchMyFiles,
+    meta: myMeta,
+    page: myPage,
+    size: mySize,
+    pagination: myPagination,
+    goToPage: myGoToPage,
+    changeSize: myChangeSize,
+    applyFilters: myApplyFilters,
   } = useDatasetList((filters, page, size) => listUserFiles(filters, page, size))
 
+  // Public Datasets
+  const {
+    datasets: publicDatasets,
+    loading: publicLoading,
+    error: publicError,
+    fetchFiles: fetchPublicFiles,
+    meta: publicMeta,
+    page: publicPage,
+    size: publicSize,
+    pagination: publicPagination,
+    goToPage: publicGoToPage,
+    changeSize: publicChangeSize,
+    applyFilters: publicApplyFilters,
+  } = useDatasetList((filters, page, size) => listFiles(filters, page, size, true))
+
   // State
-  const activeTab = ref<'upload' | 'my'>('my')
+  const activeTab = ref<'upload' | 'my' | 'public'>('my')
   const datasetQuery = ref('')
   const selectedDataset = ref<any>(null)
   const uploadOpen = ref(false)
+
+  // Derive current tab's data
+  const datasets = computed(() => (activeTab.value === 'public' ? publicDatasets.value : myDatasets.value))
+  const loading = computed(() => (activeTab.value === 'public' ? publicLoading.value : myLoading.value))
+  const error = computed(() => (activeTab.value === 'public' ? publicError.value : myError.value))
+  const meta = computed(() => (activeTab.value === 'public' ? publicMeta : myMeta))
+  const page = computed(() => (activeTab.value === 'public' ? publicPage.value : myPage.value))
+  const size = computed(() => (activeTab.value === 'public' ? publicSize.value : mySize.value))
+  const pagination = computed(() => (activeTab.value === 'public' ? publicPagination.value : myPagination.value))
+
+  const goToPage = (np: number) => {
+    if (activeTab.value === 'public') publicGoToPage(np)
+    else myGoToPage(np)
+  }
+  const changeSize = (ns: number) => {
+    if (activeTab.value === 'public') publicChangeSize(ns)
+    else myChangeSize(ns)
+  }
 
   // Methods
   const selectDataset = (dataset: any) => {
@@ -30,8 +63,8 @@ export function useAnalysisDatasets() {
   }
 
   const onUploadSuccess = async () => {
-    await fetchFiles()
-    const newest = datasets.value[0]
+    await fetchMyFiles()
+    const newest = myDatasets.value[0]
     if (newest) selectedDataset.value = newest
     uploadOpen.value = false
   }
@@ -45,20 +78,27 @@ export function useAnalysisDatasets() {
     if (value === 'upload') uploadOpen.value = true
   })
 
-  // Debounced server-side search — reset to page 1 on every query change
+  // Debounced server-side search
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
   watch(datasetQuery, (query) => {
     if (debounceTimer) clearTimeout(debounceTimer)
     debounceTimer = setTimeout(() => {
       const trimmed = query.trim()
-      applyFilters(trimmed ? { name: trimmed } : {})
-      fetchFiles({ page: 1, size: size.value })
+      const filters = trimmed ? { name: trimmed } : {}
+      if (activeTab.value === 'public') {
+        publicApplyFilters(filters)
+        fetchPublicFiles({ page: 1, size: publicSize.value })
+      } else {
+        myApplyFilters(filters)
+        fetchMyFiles({ page: 1, size: mySize.value })
+      }
     }, 300)
   })
 
   // Lifecycle
   onMounted(() => {
-    fetchFiles().catch(() => {})
+    fetchMyFiles().catch(() => {})
+    fetchPublicFiles().catch(() => {})
   })
 
   return {
@@ -75,7 +115,6 @@ export function useAnalysisDatasets() {
     pagination,
     goToPage,
     changeSize,
-    fetchFiles,
     selectDataset,
     onUploadSuccess,
     onUploadClose,

--- a/src/features/workspace/analysis/composables/usePreprocessingMethods.ts
+++ b/src/features/workspace/analysis/composables/usePreprocessingMethods.ts
@@ -268,9 +268,10 @@ export function buildDefaultMethodParams(): Record<string, string | number> {
 }
 
 const methodRulesByMode: Record<string, string[]> = {
-  profile_continuous: ['noise', 'baseline', 'norm', 'pick', 'align'],
+  // continuous 模式不支持峰对齐（数据未做峰提取，无法对齐）
+  profile_continuous: ['noise', 'baseline', 'norm', 'pick'],
   profile_processed: ['noise', 'baseline', 'norm', 'pick', 'align'],
-  centroid_continuous: ['norm', 'align'],
+  centroid_continuous: ['norm'],
   centroid_processed: ['norm', 'align'],
 }
 
@@ -281,29 +282,53 @@ function resolveModeKey(spectrumMode: string, storageMode: string): string {
 }
 
 export function usePreprocessingMethods(
-  // Arguments
   spectrumMode: Ref<string>,
   storageMode: Ref<string>,
+  /** 可选：已选中的方法（reactive 对象），用于判断 align 是否需要 pick 配合 */
+  selectedMethods?: Record<string, string>,
 ) {
-  // Computed
   const modeKey = computed(() => resolveModeKey(spectrumMode.value, storageMode.value))
 
   const isFiltered = computed(() => {
+    if (!spectrumMode.value && !storageMode.value) return false
     const allowed = methodRulesByMode[modeKey.value]
     return !!allowed && allowed.length < allMethodGroups.length
   })
 
   const modeNotice = computed(() => {
-    if (!isFiltered.value) return ''
-    const s = spectrumMode.value || 'profile'
-    const t = storageMode.value || 'continuous'
-    return `This dataset is ${s} + ${t}. Only compatible preprocessing methods are shown.`
+    const s = spectrumMode.value
+    const t = storageMode.value
+    if (!s && !t) return ''
+    const notices: string[] = []
+
+    notices.push(`This dataset is ${s || 'profile'} + ${t || 'continuous'}.`)
+
+    if (t.toLowerCase() === 'continuous') {
+      notices.push('Peak Alignment is not compatible with continuous storage.')
+    } else if (s.toLowerCase() === 'profile') {
+      notices.push('Peak Alignment requires Peak Picking to be selected first.')
+    }
+
+    notices.push('Only compatible preprocessing methods are shown.')
+    return notices.join(' ')
   })
 
   const availableMethods = computed<MethodGroup[]>(() => {
+    // 未选数据集：显示全部方法
+    if (!spectrumMode.value && !storageMode.value) return allMethodGroups
     const allowed = methodRulesByMode[modeKey.value]
     if (!allowed) return allMethodGroups
-    return allMethodGroups.filter((g) => allowed.includes(g.key))
+
+    return allMethodGroups.filter((g) => {
+      if (!allowed.includes(g.key)) return false
+
+      // profile 模式下，align 需要 pick 已选中才显示
+      if (g.key === 'align' && spectrumMode.value.toLowerCase() === 'profile') {
+        return !!selectedMethods?.['pick']
+      }
+
+      return true
+    })
   })
 
   return { availableMethods, isFiltered, modeNotice }

--- a/src/features/workspace/results/components/IonImageSection.vue
+++ b/src/features/workspace/results/components/IonImageSection.vue
@@ -3,8 +3,9 @@ import { computed, ref, watch } from 'vue'
 import IonImageViewer from '@/features/workspace/results/components/visuals/IonImageViewer.vue'
 import ROIOverlay from '@/features/workspace/results/components/visuals/ROIOverlay.vue'
 import type { ROIType } from '@/features/workspace/results/composables/useROI'
+import type { DataMode } from '@/services/zarrOssStore'
 
-defineProps<{
+const props = defineProps<{
   isStale?: boolean
   ionMatrix: Float32Array | null
   displayMatrix: Float32Array | null
@@ -24,6 +25,10 @@ defineProps<{
   calcHandleTop: (value: number) => number
   clampPct: (value: number) => number
   formatVal: (value: number) => string
+  /** 数据模式 */
+  dataMode?: DataMode | null
+  /** 当前选中像素坐标（processed 模式） */
+  selectedPixelCoord?: { x: number; y: number } | null
 }>()
 
 const emit = defineEmits<{
@@ -38,12 +43,26 @@ const emit = defineEmits<{
   (e: 'draft-updated', draft: any): void
   (e: 'draft-cleared'): void
   (e: 'roi-overlay-ref', element: InstanceType<typeof ROIOverlay> | null): void
+  /** processed 模式：点击 TIC 图像中某个像素 */
+  (e: 'select-pixel', col: number, row: number): void
 }>()
 
 const ionViewerRef = ref<InstanceType<typeof IonImageViewer> | null>(null)
 const roiOverlayRef = ref<InstanceType<typeof ROIOverlay> | null>(null)
 
 watch(roiOverlayRef, (el) => emit('roi-overlay-ref', el ?? null))
+
+/** 根据模式选择标题 */
+const imageTitle = computed(() =>
+  props.dataMode === 'processed' ? 'TIC Image' : 'Ion Image',
+)
+
+/** processed 模式下的占位提示 */
+const processedPlaceholder = computed(() =>
+  props.dataMode === 'processed' && !props.ionMatrix
+    ? 'Computing TIC image...'
+    : 'Loading ion image...',
+)
 </script>
 
 <template>
@@ -62,7 +81,7 @@ watch(roiOverlayRef, (el) => emit('roi-overlay-ref', el ?? null))
         v-else-if="!ionMatrix"
         class="flex-1 flex items-center justify-center text-base-content/40 text-lg"
       >
-        Loading ion image...
+        {{ processedPlaceholder }}
       </div>
       <div v-else class="flex-1 min-h-0 relative overflow-hidden">
         <IonImageViewer
@@ -81,10 +100,14 @@ watch(roiOverlayRef, (el) => emit('roi-overlay-ref', el ?? null))
           :overlay-data="overlayData"
           :overlay-width="ionCols"
           :overlay-height="ionRows"
+          :data-mode="dataMode"
+          :selected-pixel-coord="selectedPixelCoord"
+          :image-title="imageTitle"
           @update:mz-tolerance="emit('update:mzTolerance', $event)"
           @update:colormap="emit('update:colormap', $event)"
           @update:intensity-scale="emit('update:intensityScale', $event)"
           @reset="emit('reset-controls')"
+          @select-pixel="(col, row) => emit('select-pixel', col, row)"
         />
         <ROIOverlay
           ref="roiOverlayRef"
@@ -98,6 +121,7 @@ watch(roiOverlayRef, (el) => emit('roi-overlay-ref', el ?? null))
       </div>
     </div>
 
+    <!-- 强度条 -->
     <div class="shrink-0 flex flex-col items-center gap-1.5 w-12">
       <button
         class="text-sm text-base-content/40 hover:text-base-content"

--- a/src/features/workspace/results/components/SpectrumSection.vue
+++ b/src/features/workspace/results/components/SpectrumSection.vue
@@ -9,7 +9,13 @@ import {
   nMz,
   findClosestPeak,
   loadMeanSpectrum,
+  pixelSpectrum,
+  pixelSpectrumLoading,
+  pixelSpectrumError,
+  loadPixelSpectrum,
+  dataModeRef,
 } from '@/features/workspace/results/composables/useZarrIonImage'
+import type { DataMode } from '@/services/zarrOssStore'
 
 const props = defineProps<{
   isStale?: boolean
@@ -18,27 +24,112 @@ const props = defineProps<{
   mzTolerance: number
   intensityRange?: string
   spectrumMode?: string
+  /** 数据模式 */
+  dataMode?: DataMode | null
+  /** processed 模式下选中的像素索引 */
+  selectedPixelIndex?: number
 }>()
 
 const emit = defineEmits<{
-  /** Forwarded upwards: global mz_axis index of the clicked bar. */
+  /** continuous 模式：谱图点击 → 更新离子图 */
   (e: 'select-mz-index', index: number): void
 }>()
+
+// ---- continuous 模式数据 ----
 
 const totalPeaks = computed(() =>
   mzAxisRef.value ? mzAxisRef.value.length.toLocaleString() : '--',
 )
 
-// Map clicked m/z value → index of strongest peak within the tolerance window.
 function onSelectMz(mz: number, tolerance: number) {
   const idx = findClosestPeak(mz, tolerance)
   if (idx >= 0) emit('select-mz-index', idx)
 }
 
-// Retry mean spectrum load.
-async function onRetrySpectrum() {
+async function onRetryMeanSpectrum() {
   await loadMeanSpectrum()
 }
+
+// ---- processed 模式数据 ----
+
+/** 将 processed 模式的逐像素谱转为 chartData 格式 */
+const pixelChartData = computed<[number, number][]>(() => {
+  const spec = pixelSpectrum.value
+  if (!spec) return []
+  const { mz, intensity } = spec
+  const data: [number, number][] = []
+  for (let i = 0; i < mz.length; i++) {
+    const v = intensity[i]!
+    if (v !== 0 && Number.isFinite(v)) {
+      data.push([mz[i]!, v])
+    }
+  }
+  return data
+})
+
+/** 当前谱图数据（根据模式选择） */
+const currentChartData = computed(() =>
+  props.dataMode === 'processed' ? pixelChartData.value : meanChartData.value,
+)
+
+/** 当前加载状态 */
+const currentLoading = computed(() =>
+  props.dataMode === 'processed' ? pixelSpectrumLoading.value : spectrumLoading.value,
+)
+
+/** 当前错误状态 */
+const currentError = computed(() =>
+  props.dataMode === 'processed' ? pixelSpectrumError.value : spectrumError.value,
+)
+
+/** 当前峰数 */
+const currentPeakCount = computed(() =>
+  props.dataMode === 'processed' ? pixelChartData.value.length : nMz.value,
+)
+
+/** 当前谱图重试 */
+async function onRetry() {
+  if (props.dataMode === 'processed') {
+    const spec = pixelSpectrum.value
+    if (spec) await loadPixelSpectrum(spec.pixelIndex)
+  } else {
+    await onRetryMeanSpectrum()
+  }
+}
+
+/** 像素信息（processed 模式） */
+const pixelInfo = computed(() => {
+  const spec = pixelSpectrum.value
+  if (!spec) return null
+  return { x: spec.x, y: spec.y }
+})
+
+// ---- 底部统计信息 ----
+
+/** continuous 模式的底部统计 */
+const continuousStats = computed<{ label: string; value: string }[]>(() => [
+  { label: 'Peaks', value: totalPeaks.value },
+  { label: 'Intensity', value: props.intensityRange ?? '--' },
+  { label: 'Selected', value: props.selectedMz.toFixed(4) },
+  { label: 'Tolerance', value: `±${props.mzTolerance}` },
+])
+
+/** processed 模式的底部统计 */
+const processedStats = computed<{ label: string; value: string }[]>(() => {
+  const spec = pixelSpectrum.value
+  return [
+    { label: 'Peaks', value: pixelChartData.value.length.toLocaleString() },
+    {
+      label: 'Pixel',
+      value: spec ? `(${spec.x}, ${spec.y})` : '--',
+    },
+  ]
+})
+
+/** 当前统计信息 */
+const currentStats = computed(() =>
+  props.dataMode === 'processed' ? processedStats.value : continuousStats.value,
+)
 </script>
 
 <template>
@@ -49,36 +140,33 @@ async function onRetrySpectrum() {
     >
       No spectrum data available
     </div>
+    <div
+      v-else-if="dataMode === 'processed' && !pixelSpectrum"
+      class="flex-1 flex items-center justify-center text-base-content/40 text-lg"
+    >
+      Click a pixel on the TIC image to view its spectrum
+    </div>
     <AverageSpectrum
       v-else
-      :chart-data="meanChartData"
+      :chart-data="currentChartData"
       :selected-mz-index="selectedMzIndex"
       :selected-mz="selectedMz"
-      :loading="spectrumLoading"
-      :error="spectrumError"
-      :n-mz="nMz"
+      :loading="currentLoading"
+      :error="currentError"
+      :n-mz="currentPeakCount"
       :spectrum-mode="spectrumMode"
+      :data-mode="dataMode"
+      :pixel-info="pixelInfo"
       @select-mz="onSelectMz"
-      @retry="onRetrySpectrum"
+      @retry="onRetry"
     />
   </div>
 
+  <!-- 底部统计信息 -->
   <div class="shrink-0 flex flex-wrap gap-4 text-lg text-base-content/60 pl-4 pr-1">
-    <span>
-      Peaks:
-      <strong class="text-base-content">{{ totalPeaks }}</strong>
-    </span>
-    <span>
-      Intensity:
-      <strong class="text-base-content">{{ intensityRange }}</strong>
-    </span>
-    <span>
-      Selected:
-      <strong class="text-base-content font-mono">{{ selectedMz.toFixed(4) }}</strong>
-    </span>
-    <span>
-      Tolerance:
-      <strong class="text-base-content font-mono">&plusmn;{{ mzTolerance }}</strong>
+    <span v-for="stat in currentStats" :key="stat.label">
+      {{ stat.label }}:
+      <strong class="text-base-content font-mono">{{ stat.value }}</strong>
     </span>
   </div>
 </template>

--- a/src/features/workspace/results/components/visuals/AverageSpectrum.vue
+++ b/src/features/workspace/results/components/visuals/AverageSpectrum.vue
@@ -1,26 +1,26 @@
 <template>
   <div class="flex flex-col h-full">
-    <!-- Header -->
+    <!-- 标题区 -->
     <div class="flex items-center gap-3 mb-3">
       <div>
-        <h3 class="text-lg font-semibold">Average Spectrum</h3>
-        <p class="text-sm text-base-content/50">Mean intensity from all ion images</p>
+        <h3 class="text-lg font-semibold">{{ title }}</h3>
+        <p class="text-sm text-base-content/50">{{ description }}</p>
       </div>
-      <div v-if="!loading && !error" class="ml-auto text-base text-base-content/50 font-mono">
-        {{ nMz.toLocaleString() }} peaks
+      <div v-if="!loading && !error && showPeakCount" class="ml-auto text-base text-base-content/50 font-mono">
+        {{ peakCountLabel }}
       </div>
     </div>
 
-    <!-- Loading -->
+    <!-- 加载中 -->
     <div
       v-if="loading"
       class="flex-1 min-h-0 flex flex-col items-center justify-center gap-3 bg-base-200 rounded-lg border border-base-300"
     >
       <span class="loading loading-spinner loading-lg text-primary"></span>
-      <p class="text-lg text-base-content/60">Loading average spectrum...</p>
+      <p class="text-lg text-base-content/60">{{ loadingText }}</p>
     </div>
 
-    <!-- Error -->
+    <!-- 错误 -->
     <div
       v-else-if="error"
       class="flex-1 min-h-0 flex flex-col items-center justify-center gap-3 bg-base-200 rounded-lg border border-base-300"
@@ -31,7 +31,7 @@
       <button class="btn btn-sm btn-outline mt-2" @click="$emit('retry')">Retry</button>
     </div>
 
-    <!-- Chart -->
+    <!-- 谱图 -->
     <div
       v-else
       ref="chartContainerRef"
@@ -41,61 +41,97 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import * as echarts from 'echarts'
+import type { DataMode } from '@/services/zarrOssStore'
 
 type ChartPoint = [number, number]
 
 const props = defineProps<{
-  /** Non-zero [mz, intensity] pairs in mz_axis order. */
+  /** [mz, intensity] 数据对（按 mz 排序） */
   chartData: ChartPoint[]
-  /** Global mz_axis index of the currently selected peak. Source of truth for the red marker line. */
+  /** 全局 mz_axis 中当前选中峰的索引（仅 continuous 模式使用） */
   selectedMzIndex?: number
-  /** The m/z VALUE at selectedMzIndex (used to place the selector via convertToPixel). */
+  /** 当前选中 m/z 值（用于绘制红色标记线） */
   selectedMz?: number
   loading: boolean
   error: string | null
+  /** 总峰数（continuous 模式为 nMz，processed 模式为选中像素的峰数） */
   nMz: number
-  /** 'centroid' → bar chart (discrete peaks), 'profile' → line chart (continuous) */
+  /** 'centroid' → 柱状图, 'profile' → 折线图 */
   spectrumMode?: string
+  /** 数据模式 */
+  dataMode?: DataMode | null
+  /** processed 模式下的像素信息 */
+  pixelInfo?: { x: number; y: number } | null
 }>()
 
 const emit = defineEmits<{
-  /** Emits the m/z VALUE at the clicked pixel and a viewport-based
-   *  m/z tolerance (~10px worth) so the parent can find the strongest
-   *  real peak near the click. */
+  /** continuous 模式：点击谱图上的 m/z 位置 */
   (e: 'select-mz', mz: number, tolerance: number): void
   (e: 'retry'): void
 }>()
 
 const chartContainerRef = ref<HTMLDivElement | null>(null)
 
+/** 谱图标题 */
+const title = computed(() => {
+  if (props.dataMode === 'processed' && props.pixelInfo) {
+    return `Spectrum — Pixel (${props.pixelInfo.x}, ${props.pixelInfo.y})`
+  }
+  return props.dataMode === 'processed' ? 'Spectrum' : 'Average Spectrum'
+})
+
+/** 描述文本 */
+const description = computed(() => {
+  if (props.dataMode === 'processed') {
+    return props.pixelInfo
+      ? `Per-pixel spectrum at (${props.pixelInfo.x}, ${props.pixelInfo.y})`
+      : 'Click a pixel on the TIC image to view its spectrum'
+  }
+  return 'Mean intensity from all ion images'
+})
+
+/** 加载中文本 */
+const loadingText = computed(() =>
+  props.dataMode === 'processed' ? 'Loading spectrum...' : 'Loading average spectrum...',
+)
+
+/** 是否显示峰数 */
+const showPeakCount = computed(() =>
+  props.dataMode !== 'processed' || (props.dataMode === 'processed' && props.chartData.length > 0),
+)
+
+/** 峰数标签 */
+const peakCountLabel = computed(() => {
+  const count = props.chartData.length
+  return `${count.toLocaleString()} peaks`
+})
+
+// ---- ECharts 实例管理 ----
+
 let chartInstance: echarts.ECharts | null = null
 let resizeObserver: ResizeObserver | null = null
 let selectorTimer = 0
 let isUnmounted = false
-// Track the single datazoom listener so we can unregister it cleanly.
 let onDataZoom: (() => void) | null = null
-// Track the native click handler for cleanup.
 let nativeClickHandler: ((e: MouseEvent) => void) | null = null
 let nativeMouseDownHandler: ((e: MouseEvent) => void) | null = null
 let nativeMouseDownX = 0
 
 /**
- * Build the ECharts `graphic` payload for the red selector line + label.
- *
- * We render the selector with the `graphic` component instead of `series.markLine`
- * because markLine routes through ECharts' "axis pointer" pipeline which
- * snaps/rounds the x coordinate (verified: data x = 359.0826, computed pixel
- * via convertToPixel = 726.96, but markLine renders meaningfully off). Going
- * through `graphic` lets us place the line at an EXACT pixel x computed
- * ourselves via `convertToPixel`, so it always lines up with its bar.
- *
- * Must be called AFTER the chart is laid out (post-setOption) so
- * `convertToPixel` / `getModel().getComponent('grid')` have valid geometry.
+ * 构建红色选择线的 graphic 配置。
+ * 只在 continuous 模式下显示；processed 模式没有共享 m/z 轴，不显示。
  */
 function buildSelectorGraphic(): unknown[] {
   if (!chartInstance) return []
+  // processed 模式不显示选择线
+  if (props.dataMode === 'processed') {
+    return [
+      { id: 'mz-selector-line', $action: 'remove' },
+      { id: 'mz-selector-label', $action: 'remove' },
+    ]
+  }
   const idx = props.selectedMzIndex
   const mz = props.selectedMz
   if (idx == null || idx < 0 || mz == null) {
@@ -104,9 +140,7 @@ function buildSelectorGraphic(): unknown[] {
       { id: 'mz-selector-label', $action: 'remove' },
     ]
   }
-  // Pixel x for this mz on the current axis (already accounts for dataZoom).
   const x = chartInstance.convertToPixel({ xAxisIndex: 0 }, mz)
-  // Grid geometry — we only want the line inside the plotting area.
   const gridModel = (chartInstance as any).getModel().getComponent('grid', 0)
   const gridRect = gridModel?.coordinateSystem?.getRect?.()
   const topY = gridRect ? gridRect.y : 24
@@ -139,17 +173,11 @@ function buildSelectorGraphic(): unknown[] {
   ]
 }
 
-/** Update only the graphic layer — cheap, no re-layout. */
 function updateSelector() {
   if (!chartInstance) return
   chartInstance.setOption({ graphic: buildSelectorGraphic() as any })
 }
 
-/**
- * Same as updateSelector() but deferred — call this from inside ECharts
- * event handlers (datazoom, resize, etc.) to avoid the
- * "setOption should not be called during main process" warning.
- */
 function scheduleSelectorUpdate() {
   if (selectorTimer) return
   selectorTimer = window.setTimeout(() => {
@@ -163,7 +191,7 @@ function renderChart() {
   if (!container) { console.warn('[AverageSpectrum] No chart container'); return }
   if (isUnmounted) return
 
-  // Clean up previous DOM listeners and observer before re-creating
+  // 清理旧的事件和实例
   if (nativeMouseDownHandler) {
     container.removeEventListener('mousedown', nativeMouseDownHandler, true)
     nativeMouseDownHandler = null
@@ -178,6 +206,9 @@ function renderChart() {
   chartInstance?.dispose()
   chartInstance = echarts.init(container)
 
+  const isProfile = props.spectrumMode === 'profile'
+  const isProcessed = props.dataMode === 'processed'
+
   chartInstance.setOption(
     {
       tooltip: {
@@ -188,14 +219,17 @@ function renderChart() {
           const [mz, intensity] = items[0]!.data
           return `<div class="font-mono text-xs">
             <div>m/z: <strong>${mz}</strong></div>
-            <div>Mean intensity: <strong>${intensity}</strong></div>
+            <div>Intensity: <strong>${intensity}</strong></div>
           </div>`
         },
       },
       grid: { left: 64, right: 24, top: 24, bottom: 72 },
       xAxis: {
-        type: 'value', name: 'm/z', scale: true,
-        nameLocation: 'center', nameGap: 28,
+        type: 'value',
+        name: 'm/z',
+        scale: true,
+        nameLocation: 'center',
+        nameGap: 28,
         axisLabel: {},
         axisPointer: { label: { show: false } },
         nameTextStyle: { fontSize: 15, color: '#6b7280' },
@@ -204,8 +238,10 @@ function renderChart() {
         splitLine: { lineStyle: { color: '#e5e7eb', type: 'dashed' } },
       },
       yAxis: {
-        type: 'value', name: 'Mean intensity',
-        nameLocation: 'center', nameGap: 48,
+        type: 'value',
+        name: 'Intensity',
+        nameLocation: 'center',
+        nameGap: 48,
         nameTextStyle: { fontSize: 17, color: '#6b7280' },
         axisLine: { lineStyle: { color: '#9ca3af' } },
         axisTick: { lineStyle: { color: '#9ca3af' } },
@@ -220,9 +256,9 @@ function renderChart() {
         },
       ],
       series: [
-        props.spectrumMode === 'profile'
+        isProfile
           ? {
-              id: 'average-spectrum',
+              id: 'spectrum-series',
               type: 'line',
               data: props.chartData,
               showSymbol: false,
@@ -230,7 +266,7 @@ function renderChart() {
               areaStyle: { color: 'rgba(55, 65, 81, 0.06)' },
             }
           : {
-              id: 'average-spectrum',
+              id: 'spectrum-series',
               type: 'bar',
               data: props.chartData,
               barWidth: 3,
@@ -244,65 +280,56 @@ function renderChart() {
     { notMerge: true },
   )
 
-  // Click: native DOM listener bypasses ECharts' hit-testing (which
-  // doesn't work with large:true). We use capture phase so ECharts
-  // canvas doesn't swallow the event. A 3px drag threshold prevents
-  // dataZoom slider drags from being treated as peak selections.
-  const handleMouseDown = (e: MouseEvent) => {
-    nativeMouseDownX = e.clientX
+  // ---- 点击事件（仅 continuous 模式） ----
+
+  if (!isProcessed) {
+    const handleMouseDown = (e: MouseEvent) => {
+      nativeMouseDownX = e.clientX
+    }
+    const handleClick = (e: MouseEvent) => {
+      if (Math.abs(e.clientX - nativeMouseDownX) > 3) return
+      if (!chartInstance || !chartContainerRef.value) return
+      const rect = chartContainerRef.value.getBoundingClientRect()
+      const px = e.clientX - rect.left
+
+      const gridModel = (chartInstance as any).getModel().getComponent('grid', 0)
+      const gridRect: { x: number; y: number; width: number; height: number } | undefined =
+        gridModel?.coordinateSystem?.getRect?.()
+      const xAxis = (chartInstance as any).getModel().getComponent('xAxis', 0)
+      const axisExtent = xAxis?.axis?.scale?.getExtent?.() as [number, number] | undefined
+
+      if (!gridRect || !axisExtent) return
+      if (px < gridRect.x || px > gridRect.x + gridRect.width) return
+
+      const mz = axisExtent[0] + ((px - gridRect.x) / gridRect.width) * (axisExtent[1] - axisExtent[0])
+      if (!Number.isFinite(mz)) return
+
+      const tolerance = ((axisExtent[1] - axisExtent[0]) / gridRect.width) * 10
+      emit('select-mz', mz, tolerance)
+    }
+    nativeMouseDownHandler = handleMouseDown
+    nativeClickHandler = handleClick
+    chartContainerRef.value!.addEventListener('mousedown', handleMouseDown, true)
+    chartContainerRef.value!.addEventListener('click', handleClick, true)
   }
-  const handleClick = (e: MouseEvent) => {
-    // Ignore if mouse moved more than 3px (dataZoom drag, not a click)
-    if (Math.abs(e.clientX - nativeMouseDownX) > 3) return
-    if (!chartInstance || !chartContainerRef.value) return
-    const rect = chartContainerRef.value.getBoundingClientRect()
-    const px = e.clientX - rect.left
 
-    // Get grid geometry and axis extent for pixel→m/z interpolation.
-    const gridModel = (chartInstance as any).getModel().getComponent('grid', 0)
-    const gridRect: { x: number; y: number; width: number; height: number } | undefined =
-      gridModel?.coordinateSystem?.getRect?.()
-    const xAxis = (chartInstance as any).getModel().getComponent('xAxis', 0)
-    const axisExtent = xAxis?.axis?.scale?.getExtent?.() as [number, number] | undefined
-
-    if (!gridRect || !axisExtent) return
-
-    // Outside the plotting area → ignore (axis labels, dataZoom slider, etc.)
-    if (px < gridRect.x || px > gridRect.x + gridRect.width) return
-
-    // Linear interpolation: pixel position within the grid → m/z value
-    const mz = axisExtent[0] + ((px - gridRect.x) / gridRect.width) * (axisExtent[1] - axisExtent[0])
-    if (!Number.isFinite(mz)) return
-
-    // Viewport-based tolerance: ~10px translated to m/z units
-    const tolerance = ((axisExtent[1] - axisExtent[0]) / gridRect.width) * 10
-
-    emit('select-mz', mz, tolerance)
-  }
-  nativeMouseDownHandler = handleMouseDown
-  nativeClickHandler = handleClick
-  chartContainerRef.value!.addEventListener('mousedown', handleMouseDown, true)
-  chartContainerRef.value!.addEventListener('click', handleClick, true)
-
-  // Keep the manual selector glued to its bar through pan / zoom / slider drag.
+  // dataZoom 监听
   onDataZoom = () => scheduleSelectorUpdate()
   chartInstance.on('datazoom', onDataZoom)
 
+  // 响应式调整
   resizeObserver = new ResizeObserver(() => {
     chartInstance?.resize()
     scheduleSelectorUpdate()
   })
   resizeObserver.observe(chartContainerRef.value!)
 
-  // First paint of the selector — safe to call sync here.
   updateSelector()
 }
 
-// ===== Lifecycle =====
+// ===== 生命周期 =====
 
 onMounted(() => {
-  // chartData may already be ready when mounted; render immediately if so.
-  // If still loading, chart will render when chartData prop changes.
   if (!props.loading && !props.error && props.chartData.length > 0) {
     renderChart()
   }
@@ -326,10 +353,7 @@ onBeforeUnmount(() => {
   chartInstance = null
 })
 
-// chartData is loaded asynchronously — re-render when it arrives.
-// flush: 'post' is required because the chart container is behind a
-// v-else (gated on loading/error), and watchers fire before DOM updates
-// by default. Without it, renderChart() sees a null chartContainerRef.
+// chartData 变化时重新渲染
 watch(
   () => props.chartData,
   (data) => {
@@ -340,7 +364,7 @@ watch(
   { flush: 'post' },
 )
 
-// Move the red selector line whenever the selected m/z changes.
+// 选中 m/z 变化时移动红线
 watch(
   () => props.selectedMzIndex,
   () => {
@@ -349,7 +373,7 @@ watch(
   },
 )
 
-// Re-render chart when spectrum mode changes (centroid ↔ profile).
+// spectrumMode 变化时重新渲染
 watch(
   () => props.spectrumMode,
   () => {

--- a/src/features/workspace/results/components/visuals/IonImageToolbar.vue
+++ b/src/features/workspace/results/components/visuals/IonImageToolbar.vue
@@ -1,14 +1,27 @@
 <template>
   <div class="flex flex-wrap items-center gap-3 mb-3 pt-1">
     <div>
-      <h3 class="text-lg font-semibold">Ion Image</h3>
+      <h3 class="text-lg font-semibold">{{ title }}</h3>
     </div>
     <div class="ml-auto flex flex-wrap items-center gap-2">
-      <div class="bg-base-100 border border-base-300 rounded-lg px-3 py-1 text-base h-8 flex items-center">
+      <!-- m/z 显示（continuous 模式） -->
+      <div
+        v-if="dataMode === 'continuous'"
+        class="bg-base-100 border border-base-300 rounded-lg px-3 py-1 text-base h-8 flex items-center"
+      >
         <span class="text-base-content/50">m/z&nbsp;</span>
         <span class="font-mono font-semibold">{{ selectedMz.toFixed(4) }}</span>
       </div>
-      <div class="flex items-center gap-1 text-base">
+      <!-- 像素坐标显示（processed 模式） -->
+      <div
+        v-if="dataMode === 'processed' && pixelCoord"
+        class="bg-base-100 border border-base-300 rounded-lg px-3 py-1 text-base h-8 flex items-center"
+      >
+        <span class="text-base-content/50">Pixel&nbsp;</span>
+        <span class="font-mono font-semibold">({{ pixelCoord.x }}, {{ pixelCoord.y }})</span>
+      </div>
+      <!-- m/z 容差（仅 continuous 模式） -->
+      <div v-if="dataMode === 'continuous'" class="flex items-center gap-1 text-base">
         <span class="text-base-content/50">Tolerance &plusmn;</span>
         <input
           type="number"
@@ -19,6 +32,7 @@
           @input="$emit('update:mzTolerance', +($event.target as HTMLInputElement).value)"
         />
       </div>
+      <!-- Colormap（两种模式都可用） -->
       <select
         class="select select-sm select-bordered w-28 text-base"
         :value="colormap"
@@ -29,6 +43,7 @@
         <option value="plasma">Plasma</option>
         <option value="gray">Gray</option>
       </select>
+      <!-- 强度标度 -->
       <select
         class="select select-sm select-bordered w-28 text-base"
         :value="intensityScale"
@@ -43,11 +58,19 @@
 </template>
 
 <script setup lang="ts">
+import type { DataMode } from '@/services/zarrOssStore'
+
 defineProps<{
   selectedMz: number
   mzTolerance: number
   colormap: string
   intensityScale: string
+  /** 数据模式 */
+  dataMode?: DataMode | null
+  /** 当前选中像素坐标（processed 模式） */
+  pixelCoord?: { x: number; y: number } | null
+  /** 工具栏标题 */
+  title?: string
 }>()
 
 defineEmits<{

--- a/src/features/workspace/results/components/visuals/IonImageViewer.vue
+++ b/src/features/workspace/results/components/visuals/IonImageViewer.vue
@@ -5,6 +5,9 @@
       :mz-tolerance="mzTolerance"
       :colormap="colormap"
       :intensity-scale="intensityScale"
+      :data-mode="dataMode"
+      :pixel-coord="selectedPixelCoord"
+      :title="imageTitle"
       @update:mz-tolerance="$emit('update:mzTolerance', $event)"
       @update:colormap="$emit('update:colormap', $event)"
       @update:intensity-scale="$emit('update:intensityScale', $event)"
@@ -13,8 +16,9 @@
     <div
       ref="containerRef"
       class="relative flex-1 min-h-0 bg-base-200 rounded-lg border border-base-300 overflow-hidden"
-      :class="drawMode ? 'cursor-default' : zoom > 1 ? 'cursor-grab' : 'cursor-crosshair'"
-      @mousedown="onContainerPanStart"
+      :class="containerCursorClass"
+      @mousedown="onContainerMouseDown"
+      @click="onContainerClick"
       @mousemove="onHover"
       @mouseleave="hoverPixel = null"
     >
@@ -30,13 +34,21 @@
         }"
         @wheel.prevent="onContainerWheel"
       />
+      <!-- 悬停提示 -->
       <div
         v-if="hoverPixel"
         class="absolute pointer-events-none bg-base-100/90 backdrop-blur-sm text-sm px-2 py-1 rounded shadow border border-base-300 font-mono"
         :style="{ left: hoverPixel.x + 12 + 'px', top: hoverPixel.y + 12 + 'px' }"
       >
-        ({{ hoverPixel.col }}, {{ hoverPixel.row }}) — {{ hoverPixel.intensity.toExponential(2) }}
+        <template v-if="dataMode === 'processed'">
+          ({{ hoverPixel.col }}, {{ hoverPixel.row }})
+          {{ hoverPixel.intensity.toExponential(2) }}
+        </template>
+        <template v-else>
+          ({{ hoverPixel.col }}, {{ hoverPixel.row }}) — {{ hoverPixel.intensity.toExponential(2) }}
+        </template>
       </div>
+      <!-- 缩放控件 -->
       <div
         class="absolute bottom-2 right-2 flex items-center gap-1 bg-base-100/80 backdrop-blur-sm rounded-lg px-1.5 py-1 border border-base-300"
       >
@@ -75,6 +87,7 @@ import { ref, computed, watch, onMounted, type PropType } from 'vue'
 import IonImageToolbar from './IonImageToolbar.vue'
 import { useZoomPan } from '../../composables/useZoomPan'
 import { useCanvasRenderer } from '../../composables/useCanvasRenderer'
+import type { DataMode } from '@/services/zarrOssStore'
 
 const props = defineProps({
   selectedMz: { type: Number, required: true },
@@ -91,26 +104,34 @@ const props = defineProps({
   overlayData: { type: Object as PropType<Uint8ClampedArray | null>, default: null },
   overlayWidth: { type: Number, default: 0 },
   overlayHeight: { type: Number, default: 0 },
+  /** 数据模式 */
+  dataMode: { type: String as PropType<DataMode | null>, default: null },
+  /** 当前选中像素坐标（processed 模式） */
+  selectedPixelCoord: { type: Object as PropType<{ x: number; y: number } | null>, default: null },
+  /** 图片区域标题 */
+  imageTitle: { type: String, default: 'Ion Image' },
 })
 
-defineEmits<{
+const emit = defineEmits<{
   (e: 'update:mzTolerance', v: number): void
   (e: 'update:colormap', v: string): void
   (e: 'update:intensityScale', v: string): void
   (e: 'reset'): void
+  /** processed 模式：点击像素 */
+  (e: 'select-pixel', col: number, row: number): void
 }>()
 
 const canvasRef = ref<HTMLCanvasElement | null>(null)
 const containerRef = ref<HTMLDivElement | null>(null)
 const hoverPixel = ref<{
-  x: number
-  y: number
-  row: number
-  col: number
-  intensity: number
+  x: number; y: number; row: number; col: number; intensity: number
 } | null>(null)
 const containerW = ref(0)
 const containerH = ref(0)
+
+// 区分拖拽和点击
+let mouseDownPos = { x: 0, y: 0 }
+let mouseMoved = false
 
 // --- Composables ---
 const { zoom, panX, panY, resetZoom, zoomIn, zoomOut, onWheel, onPanStart } = useZoomPan(
@@ -135,19 +156,79 @@ const { scheduleRender, observeContainer } = useCanvasRenderer({
   overlayHeight: computed(() => props.overlayHeight),
 })
 
+/** 容器光标样式 */
+const containerCursorClass = computed(() => {
+  if (props.drawMode) return 'cursor-default'
+  if (props.dataMode === 'processed') return 'cursor-crosshair'
+  if (zoom.value > 1) return 'cursor-grab'
+  return 'cursor-crosshair'
+})
+
 function onContainerWheel(e: WheelEvent) {
   if (props.drawMode) return
   onWheel(e, containerRef.value)
-  // Zoom/pan is handled by CSS transform — canvas content stays the same.
 }
 
-function onContainerPanStart(e: MouseEvent) {
+// --- 鼠标事件：拖拽 + 点击 ---
+
+function onContainerMouseDown(e: MouseEvent) {
+  mouseDownPos = { x: e.clientX, y: e.clientY }
+  mouseMoved = false
+
   if (props.drawMode) return
-  onPanStart(e, containerRef.value)
-  // Zoom/pan is handled by CSS transform — canvas content stays the same.
+
+  // 缩放 > 1 时支持拖拽平移
+  if (zoom.value > 1 && e.button === 0) {
+    onPanStart(e, containerRef.value)
+    // 监听 mouseup 来判断是拖拽还是点击
+    const onUp = (ev: MouseEvent) => {
+      const dx = ev.clientX - mouseDownPos.x
+      const dy = ev.clientY - mouseDownPos.y
+      mouseMoved = Math.abs(dx) > 3 || Math.abs(dy) > 3
+      document.removeEventListener('mouseup', onUp)
+    }
+    document.addEventListener('mouseup', onUp)
+  }
 }
 
-// --- Hover ---
+// 在容器的 click 事件中处理像素选择
+function onContainerClick(e: MouseEvent) {
+  if (mouseMoved) return  // 拖拽不触发点击
+  if (props.drawMode) return
+  if (props.dataMode !== 'processed') return  // 仅 processed 模式
+
+  const container = containerRef.value
+  if (!container) return
+  const rect = container.getBoundingClientRect()
+  const data = props.matrix
+  const cols = props.matrixCols
+  const rows = props.matrixRows
+  if (!data || !data.length || !cols || !rows) return
+
+  const W = rect.width, H = rect.height
+  const pad = 0.04
+  const availW = W * (1 - pad * 2)
+  const availH = H * (1 - pad * 2)
+  const scaleVal = Math.min(availW / cols, availH / rows)
+  const drawW = Math.floor(cols * scaleVal)
+  const drawH = Math.floor(rows * scaleVal)
+  const ox = Math.floor((W - drawW) / 2)
+  const oy = Math.floor((H - drawH) / 2)
+
+  const mx = e.clientX - rect.left
+  const my = e.clientY - rect.top
+  const cx = (mx - panX.value) / zoom.value
+  const cy = (my - panY.value) / zoom.value
+  const col = Math.floor((cx - ox) * cols / drawW)
+  const row = Math.floor((cy - oy) * rows / drawH)
+
+  if (row >= 0 && row < rows && col >= 0 && col < cols) {
+    emit('select-pixel', col, row)
+  }
+}
+
+// --- 悬停 ---
+
 function onHover(e: MouseEvent) {
   const container = containerRef.value
   if (!container) return
@@ -156,8 +237,7 @@ function onHover(e: MouseEvent) {
   const cols = props.matrixCols
   const rows = props.matrixRows
   if (!data || !data.length || !cols || !rows) return
-  const W = rect.width,
-    H = rect.height
+  const W = rect.width, H = rect.height
   const pad = 0.04
   const availW = W * (1 - pad * 2)
   const availH = H * (1 - pad * 2)
@@ -180,6 +260,7 @@ function onHover(e: MouseEvent) {
 }
 
 // --- Lifecycle ---
+
 onMounted(() => {
   if (containerRef.value) {
     observeContainer(containerRef.value)

--- a/src/features/workspace/results/composables/useResultMeta.ts
+++ b/src/features/workspace/results/composables/useResultMeta.ts
@@ -1,5 +1,6 @@
-import { ref, watch, type Ref } from 'vue'
-import { getFileMetadata } from '@/features/datasets/api/datasetApi'
+import { ref, watch, computed, type Ref } from 'vue'
+import { metadataAttrsRef, dataModeRef } from '@/features/workspace/results/composables/useZarrIonImage'
+import type { DataMode } from '@/services/zarrOssStore'
 
 interface ResultDetailState {
   runId?: string
@@ -23,49 +24,62 @@ export function useResultMeta(runId: Ref<string>) {
   const methods = ref<string[]>([])
   const loading = ref(false)
 
+  /** 当前数据模式（continuous / processed），从 zarr store 获取 */
+  const dataMode = ref<DataMode | null>(null)
+
   function formatPixelSize(x?: number, y?: number): string {
     if (x != null && y != null) return `${x} × ${y} µm`
     return ''
   }
 
-  /** Adjust displayed mode based on applied processing methods */
-  function applyProcessingAdjustments() {
-    const hasPeakPicking = methods.value.includes('Peak Picking')
-    const hasPeakAlignment = methods.value.includes('Peak Alignment')
+  /** 从 zarr metadata/zarr.json 读取所有元数据 */
+  function applyZarrMetadata() {
+    const attrs = metadataAttrsRef.value
+    if (!attrs) return
 
-    if (hasPeakPicking) spectrumMode.value = 'centroid'
-    if (hasPeakAlignment) storageMode.value = 'continuous'
+    // 谱图模式
+    if (attrs.centroid_spectrum) spectrumMode.value = 'centroid'
+    else if (attrs.profile_spectrum) spectrumMode.value = 'profile'
+
+    // 数据模式
+    dataMode.value = dataModeRef.value
+
+    // 仪器型号
+    if (attrs.analyzer) analyzer.value = attrs.analyzer
+
+    // 离子源
+    if (attrs.ionisation_source) ionSource.value = attrs.ionisation_source
+
+    // 极性
+    if (attrs.polarity) polarity.value = attrs.polarity
+
+    // 存储模式
+    if (attrs.continuous) storageMode.value = 'continuous'
+    else if (attrs.processed) storageMode.value = 'processed'
+
+    // 像素大小
+    if (attrs.pixel_size_horizontal != null && attrs.pixel_size_vertical != null) {
+      pixelSize.value = formatPixelSize(attrs.pixel_size_horizontal, attrs.pixel_size_vertical)
+    }
+
+    // 数据集名称（zarr 有则用，否则沿用 router state）
+    if (attrs.name && !datasetName.value) {
+      datasetName.value = attrs.name
+    }
   }
 
-  async function fetchMeta(_id: string) {
+  function fetchMeta(_id: string) {
     loading.value = true
     try {
       const state = history.state as ResultDetailState | null
 
-      // Read process info directly from router state (passed by WorkspaceTable)
+      // 从 router state 读取 process 层面的信息
       datasetName.value = state?.datasetName || ''
       status.value = (state?.status || '').toLowerCase()
       methods.value = state?.methods || []
 
-      // Fetch file metadata for instrument params
-      const fileId = state?.fileId
-      if (fileId != null) {
-        try {
-          const file = await getFileMetadata(fileId)
-          if (file) {
-            analyzer.value = file.analyzer || ''
-            ionSource.value = file.ionisation_source || ''
-            pixelSize.value = formatPixelSize(file.pixel_size_horizontal, file.pixel_size_vertical)
-            polarity.value = file.polarity || ''
-            spectrumMode.value = file.spectrum_mode || ''
-            storageMode.value = file.storage_mode || ''
-          }
-        } catch {
-          // file lookup is optional
-        }
-      }
-
-      applyProcessingAdjustments()
+      // 从 zarr metadata 覆盖/补充元数据
+      applyZarrMetadata()
     } catch (e) {
       console.error('[useResultMeta] fetch failed:', e)
     } finally {
@@ -73,9 +87,32 @@ export function useResultMeta(runId: Ref<string>) {
     }
   }
 
+  // 当 runId 变化时重新获取
   watch(runId, (id) => {
     if (id) fetchMeta(id)
   }, { immediate: true })
 
-  return { datasetName, analyzer, ionSource, pixelSize, polarity, spectrumMode, storageMode, status, methods, loading }
+  // 当 zarr metadata 加载完成后更新（store.init() 会设置 metadataAttrsRef）
+  watch(metadataAttrsRef, () => {
+    applyZarrMetadata()
+  })
+
+  // 当 dataMode 变化时同步
+  watch(dataModeRef, (mode) => {
+    dataMode.value = mode
+  })
+
+  return {
+    datasetName,
+    analyzer,
+    ionSource,
+    pixelSize,
+    polarity,
+    spectrumMode,
+    storageMode,
+    status,
+    methods,
+    loading,
+    dataMode,
+  }
 }

--- a/src/features/workspace/results/composables/useZarrIonImage.ts
+++ b/src/features/workspace/results/composables/useZarrIonImage.ts
@@ -1,61 +1,124 @@
 /**
- * Ion image composable — loads zarr chunks on demand via OSS STS.
+ * Ion image composable — loads zarr data on demand via OSS STS.
  *
- * selectedMzIndex is the single source of truth; selectedMz is derived from it.
- * The markLine red axis aligns precisely by avoiding floating-point round-trips.
+ * Supports two data modes:
+ *   - continuous (ion-major): average spectrum + ion image  (existing feature)
+ *   - processed (pixel-major): TIC image + per-pixel spectrum (new feature)
+ *
+ * selectedMzIndex is the single source of truth for continuous mode;
+ * selectedPixelIndex is the source of truth for processed mode.
+ * selectedMz is derived from selectedMzIndex + mzAxis (continuous only).
  */
+
 import { computed, ref, shallowRef } from 'vue'
 import { getZarrAccess } from '@/services/zarrAccessApi'
-import { ZarrOssStore, type IonImageInfo } from '@/services/zarrOssStore'
+import {
+  ZarrOssStore,
+  type IonImageInfo,
+  type PixelSpectrum,
+  type MetadataAttrs,
+  type DataMode,
+} from '@/services/zarrOssStore'
 import { ZARR_STORE } from '@/shared/config/defaults'
 
-/** Module-level shared state; mzAxis uses shallowRef so computed tracks changes */
+// ---- Module-level shared state ----
+
 let store: ZarrOssStore | null = null
+
+/** Shared m/z axis (Float64Array). Only populated for continuous mode. */
 const mzAxisRef = shallowRef<Float64Array | null>(null)
+
+/** Ion image dimensions { width, height } */
 const ionDims = shallowRef<{ width: number; height: number } | null>(null)
 
-// ---- Mean spectrum state (managed here so no component needs store access) ----
+/** Data mode: 'continuous' or 'processed' */
+export const dataModeRef = shallowRef<DataMode | null>(null)
+
+/** Row axis: 'pixel' or 'ion' */
+export const rowAxisRef = shallowRef<'pixel' | 'ion' | null>(null)
+
+/** Metadata from /metadata/.zattrs */
+export const metadataAttrsRef = shallowRef<MetadataAttrs | null>(null)
+
+// ---- Mean spectrum state (continuous mode) ----
+
 export const meanChartData = shallowRef<[number, number][]>([])
 export const spectrumLoading = ref(false)
 export const spectrumError = ref<string | null>(null)
 export const nMz = ref(0)
 
-export type MeanSpectrumState = {
+// ---- TIC image state (processed mode) ----
+
+export const ticMatrix = shallowRef<Float32Array | null>(null)
+export const ticLoading = ref(false)
+export const ticError = ref<string | null>(null)
+
+// ---- Per-pixel spectrum state (processed mode) ----
+
+export const pixelSpectrum = shallowRef<{
+  mz: Float64Array
+  intensity: Float32Array
+  pixelIndex: number
+  x: number
+  y: number
+} | null>(null)
+
+export const pixelSpectrumLoading = ref(false)
+export const pixelSpectrumError = ref<string | null>(null)
+
+// ---- Shared context snapshot ----
+
+export interface SharedZarrContext {
+  store: ZarrOssStore | null
+  mzAxis: Float64Array | null
+  ionShape: { width: number; height: number } | null
+  dataMode: DataMode | null
+  rowAxis: 'pixel' | 'ion' | null
   meanChartData: [number, number][]
   spectrumLoading: boolean
   spectrumError: string | null
   nMz: number
+  ticMatrix: Float32Array | null
+  pixelSpectrum: typeof pixelSpectrum.value
 }
 
-export function getSharedZarrContext(): {
-  store: ZarrOssStore | null
-  mzAxis: Float64Array | null
-  ionShape: { width: number; height: number } | null
-} & MeanSpectrumState {
+export function getSharedZarrContext(): SharedZarrContext {
   return {
     store,
     mzAxis: mzAxisRef.value,
     ionShape: ionDims.value,
+    dataMode: dataModeRef.value,
+    rowAxis: rowAxisRef.value,
     meanChartData: meanChartData.value,
     spectrumLoading: spectrumLoading.value,
     spectrumError: spectrumError.value,
     nMz: nMz.value,
+    ticMatrix: ticMatrix.value,
+    pixelSpectrum: pixelSpectrum.value,
   }
 }
 
+// ---- Mean spectrum loading (continuous mode) ----
+
 /**
- * Load the mean spectrum from the zarr store and derive non-zero chart data.
- * Only exported so SpectrumSection can call retry; normally invoked from init().
+ * Load the mean spectrum from stats/mean_spectrum and derive non-zero chart data.
+ * Only valid for continuous mode.
  */
 export async function loadMeanSpectrum(): Promise<void> {
   const axis = mzAxisRef.value
   if (!store || !axis) return
+  if (dataModeRef.value !== 'continuous') return
 
   spectrumLoading.value = true
   spectrumError.value = null
 
   try {
     const meanData = await store.loadMeanSpectrum()
+    if (!meanData) {
+      spectrumLoading.value = false
+      spectrumError.value = 'Mean spectrum not available'
+      return
+    }
 
     nMz.value = axis.length
     const data: [number, number][] = []
@@ -74,7 +137,60 @@ export async function loadMeanSpectrum(): Promise<void> {
   }
 }
 
+// ---- TIC image loading (processed mode) ----
+
+export async function loadTICImage(): Promise<void> {
+  if (!store) return
+  if (dataModeRef.value !== 'processed') return
+
+  ticLoading.value = true
+  ticError.value = null
+
+  try {
+    const matrix = await store.computeTICImage()
+    ticMatrix.value = matrix
+    ticLoading.value = false
+  } catch (e) {
+    console.error('[useZarrIonImage] loadTICImage failed:', e)
+    ticLoading.value = false
+    ticError.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+// ---- Per-pixel spectrum loading (processed mode) ----
+
+export async function loadPixelSpectrum(pixelIndex: number): Promise<void> {
+  if (!store) return
+  if (dataModeRef.value !== 'processed') return
+
+  pixelSpectrumLoading.value = true
+  pixelSpectrumError.value = null
+  pixelSpectrum.value = null
+
+  try {
+    const spectrum = await store.getPixelSpectrum(pixelIndex)
+    if (!spectrum) {
+      pixelSpectrumLoading.value = false
+      pixelSpectrumError.value = 'Empty spectrum for this pixel'
+      return
+    }
+
+    // Convert to chart data: only non-zero finite values
+    const { mz, intensity, pixelIndex: idx, x, y } = spectrum
+    pixelSpectrum.value = { mz, intensity, pixelIndex: idx, x, y }
+    pixelSpectrumLoading.value = false
+  } catch (e) {
+    console.error('[useZarrIonImage] loadPixelSpectrum failed:', e)
+    pixelSpectrumLoading.value = false
+    pixelSpectrumError.value = e instanceof Error ? e.message : String(e)
+  }
+}
+
+// ---- Exports ----
+
 export { mzAxisRef }
+
+// ---- Helper: find m/z range indices (continuous mode) ----
 
 function findMzRangeIndices(targetIdx: number, tolerance: number): number[] {
   const mzAxis = mzAxisRef.value
@@ -89,6 +205,8 @@ function findMzRangeIndices(targetIdx: number, tolerance: number): number[] {
   }
   return indices.length ? indices : [targetIdx]
 }
+
+// ---- Helper: load ion image slice sum (continuous mode) ----
 
 async function loadIonSliceSum(indices: number[]): Promise<Float32Array | null> {
   if (!store || !indices.length || !ionDims.value) return null
@@ -106,53 +224,39 @@ async function loadIonSliceSum(indices: number[]): Promise<Float32Array | null> 
   return sum
 }
 
-/**
- * Binary search in mzAxis for the index closest to target.
- * Returns -1 if mzAxis is empty.
- */
+// ---- Binary search in m/z axis ----
+
 export function findClosestMzIndex(target: number): number {
   const a = mzAxisRef.value
   if (!a || !a.length) return -1
-
   if (target <= a[0]!) return 0
-
   const lastIndex = a.length - 1
   if (target >= a[lastIndex]!) return lastIndex
 
   let lo = 0
   let hi = lastIndex
-
   while (lo < hi) {
     const mid = (lo + hi) >>> 1
     if (a[mid]! < target) lo = mid + 1
     else hi = mid
   }
-
   const prev = lo - 1
-
-  return Math.abs(target - a[prev]!) <= Math.abs(a[lo]! - target)
-    ? prev
-    : lo
+  return Math.abs(target - a[prev]!) <= Math.abs(a[lo]! - target) ? prev : lo
 }
 
-/**
- * Find the closest real peak to the clicked m/z value, constrained
- * within a viewport-based tolerance so we don't snap to a peak far
- * from the click position.
- */
 export function findClosestPeak(mz: number, tolerance: number): number {
   const axis = mzAxisRef.value
   if (!axis || !axis.length) return -1
-
   const idx = findClosestMzIndex(mz)
   if (idx < 0) return -1
-
-  // Gate: only accept if the closest peak falls within tolerance
   if (Math.abs(axis[idx]! - mz) <= tolerance) return idx
   return -1
 }
 
+// ---- Main composable ----
+
 export function useZarrIonImage() {
+  // Continuous mode state
   const selectedMzIndex = ref(0)
   const mzTolerance = ref<number>(ZARR_STORE.defaultMzTolerance)
   const ionMatrix = ref<Float32Array | null>(null)
@@ -160,13 +264,20 @@ export function useZarrIonImage() {
   const error = ref<string | null>(null)
   const ready = ref(false)
 
+  // Processed mode state
+  const selectedPixelIndex = ref(-1)
+
+  // Computed
   const ionCols = computed(() => ionDims.value?.width ?? 0)
   const ionRows = computed(() => ionDims.value?.height ?? 0)
-  const totalPeaks = computed(() => (mzAxisRef.value ? mzAxisRef.value.length.toLocaleString() : '--'))
+  const totalPeaks = computed(() =>
+    mzAxisRef.value ? mzAxisRef.value.length.toLocaleString() : '--',
+  )
 
-  // selectedMz is DERIVED from selectedMzIndex + mzAxis — never written directly.
-  // This guarantees the displayed/passed-down m/z value is exactly the one stored
-  // in zarr's mz_axis, with no float round-trip or display-precision loss.
+  const isContinuous = computed(() => dataModeRef.value === 'continuous')
+  const isProcessed = computed(() => dataModeRef.value === 'processed')
+
+  // selectedMz is DERIVED from selectedMzIndex + mzAxis — never written directly
   const selectedMz = computed(() => {
     const axis = mzAxisRef.value
     const idx = selectedMzIndex.value
@@ -174,19 +285,17 @@ export function useZarrIonImage() {
     return axis[idx]!
   })
 
+  // ---- Continuous mode: load ion image for a given m/z index ----
+
   const loadForMzIndex = async (idx: number) => {
     if (!mzAxisRef.value || !ready.value || idx < 0 || idx >= mzAxisRef.value.length) return
+    if (dataModeRef.value !== 'continuous') return
     loading.value = true
     selectedMzIndex.value = idx
     ionMatrix.value = await loadIonSliceSum(findMzRangeIndices(idx, mzTolerance.value))
     loading.value = false
   }
 
-  // ===== Public API: spectrum bar click delivers a global mz_axis index =====
-  // The spectrum component emits the interpolated m/z value + tolerance,
-  // then SpectrumSection calls findPeakIndex() to locate the strongest real
-  // peak in the raw mean data within that tolerance window — no reliance on
-  // chart dataIndex which only covers non-zero points.
   const onSpectrumClickByIndex = async (idx: number) => {
     if (!mzAxisRef.value || !ready.value) return
     if (idx < 0 || idx >= mzAxisRef.value.length) return
@@ -199,30 +308,82 @@ export function useZarrIonImage() {
     await loadForMzIndex(idx)
   }
 
-  // ===== Initialization =====
+  // ---- Processed mode: load pixel spectrum ----
+
+  const loadSpectrumForPixel = async (pixelIdx: number) => {
+    if (!ready.value) return
+    if (dataModeRef.value !== 'processed') return
+    selectedPixelIndex.value = pixelIdx
+    await loadPixelSpectrum(pixelIdx)
+  }
+
+  // ---- Initialization ----
+
   const init = async (runId: string) => {
     if (!runId) return
     loading.value = true
     error.value = null
     ready.value = false
+
+    // Reset all state
     store = null
     mzAxisRef.value = null
     ionDims.value = null
     ionMatrix.value = null
-    // Reset mean spectrum state so the old chart doesn't flash.
+    dataModeRef.value = null
+    rowAxisRef.value = null
+    metadataAttrsRef.value = null
+
+    // Reset mean spectrum state
     meanChartData.value = []
     spectrumLoading.value = false
     spectrumError.value = null
+
+    // Reset TIC state
+    ticMatrix.value = null
+    ticLoading.value = false
+    ticError.value = null
+
+    // Reset per-pixel spectrum state
+    pixelSpectrum.value = null
+    pixelSpectrumLoading.value = false
+    pixelSpectrumError.value = null
+
     try {
       const access = await getZarrAccess(runId)
-      store = new ZarrOssStore(access, { ionChunkCacheSize: ZARR_STORE.ionChunkCacheSize })
+      store = new ZarrOssStore(access, {
+        intensityChunkCacheSize: ZARR_STORE.intensityChunkCacheSize,
+      })
       await store.init()
-      mzAxisRef.value = (await store.loadMzAxis()) as Float64Array
-      const shape = store.getIonShape()
-      if (shape && shape.length >= 3) ionDims.value = { width: shape[2]!, height: shape[1]! }
-      ready.value = true
-      await loadDefaultImage()
-      loadMeanSpectrum()   // background: ion image is already ready
+
+      // Set mode and row axis
+      dataModeRef.value = store.dataMode
+      rowAxisRef.value = store.rowAxis
+      metadataAttrsRef.value = store.metadataAttrs
+
+      // Set spatial dimensions
+      const [height, width] = store.spatialShape
+      ionDims.value = { width, height }
+
+      if (store.dataMode === 'continuous') {
+        // Load shared m/z axis
+        const mzAxis = await store.loadMzAxis()
+        mzAxisRef.value = mzAxis
+
+        // Set ion shape for backward compat
+        const shape = store.getIonShape()
+        if (shape) {
+          ionDims.value = { width: shape[2]!, height: shape[1]! }
+        }
+
+        ready.value = true
+        await loadDefaultImage()
+        loadMeanSpectrum() // background
+      } else {
+        // Processed mode: load TIC image
+        ready.value = true
+        await loadTICImage()
+      }
     } catch (e) {
       console.error('[useZarrIonImage] init failed:', e)
       error.value = e instanceof Error ? e.message : String(e)
@@ -232,6 +393,7 @@ export function useZarrIonImage() {
   }
 
   return {
+    // Common
     selectedMzIndex,
     selectedMz,
     mzTolerance,
@@ -239,11 +401,19 @@ export function useZarrIonImage() {
     ionCols,
     ionRows,
     totalPeaks,
-    onSpectrumClickByIndex,
-    loadForMzIndex,
+    isContinuous,
+    isProcessed,
     loading,
     error,
     ready,
     init,
+
+    // Continuous mode
+    onSpectrumClickByIndex,
+    loadForMzIndex,
+
+    // Processed mode
+    selectedPixelIndex,
+    loadSpectrumForPixel,
   }
 }

--- a/src/services/zarrOssStore.ts
+++ b/src/services/zarrOssStore.ts
@@ -1,41 +1,36 @@
 /**
- * On-demand reader for zarr v3 data stored in Alibaba Cloud OSS, with
- * decoding. Downloads one chunk at a time and caches the last N via LRU.
+ * On-demand reader for MassFlow MSI Zarr v1.0 data stored in Alibaba Cloud OSS.
  *
- * Pipeline: STS token → OSS GET → zarr metadata → chunk path resolution
- *           → decode → ion image.
+ * New format (v1.0) supports two data layouts:
+ *   - ion-major continuous → ion image + mean spectrum (existing feature)
+ *   - pixel-major processed → TIC image + per-pixel spectrum (new feature)
  *
- * Concurrency: requests for the same chunk share a single in-flight Promise.
- * Also kicks off background prefetches of neighboring chunks; prefetch
- * failures never block the main image request.
+ * Layout (see public/zarr_schema.md):
+ *   <root>/.zattrs              — root attributes (format, spatial_shape, etc.)
+ *   <root>/metadata/.zattrs     — semantic metadata
+ *   <root>/axes/coordinates     — (n_pixels, 3) uint32, pixel coordinates
+ *   <root>/axes/mz              — shared m/z axis (continuous only)
+ *   <root>/data/.zattrs         — row_axis + encoding
+ *   <root>/data/intensity/      — 1D float32, flattened intensity values
+ *   <root>/data/offsets/        — (n_rows+1,) int64, row boundary indices
+ *   <root>/data/mz/             — per-point m/z (processed only)
+ *   <root>/stats/mean_spectrum/ — optional, pre-computed mean spectrum
  *
- * Supported codecs: gzip / zlib / deflate (via native DecompressionStream),
- * zstd (via zstddec); unsupported codecs raise a clear error.
+ * Chunk caching: intensity chunks use LRU cache (default 20 chunks).
+ * In-flight request deduplication prevents redundant OSS requests for
+ * the same chunk.
  *
- * Zarr layout assumed by this project:
- *   <root>/zarr.json
- *   <root>/mz_axis/zarr.json + chunk files
- *   <root>/ion_images/zarr.json + chunk files
- *       shape: [nMz, H, W], chunk shape typically [16, H, W]
- *
- * Chunk key encoding (zarr v3 default encoding "default"):
- *   <root>/ion_images/c<chunkIndex>/<innerChunkKey>
- *   where innerChunkKey is the dimension indices joined by the configured
- *   separator (default ".").
- *
- *   Example (ndim=3, chunk_shape=[16, H, W], full chunks):
- *     ion_images/c0/0.0.0
- *     ion_images/c1/0.0.0
- *     ...
+ * Supported codecs: gzip / zlib / deflate (native DecompressionStream),
+ * zstd (via zstddec).
  */
 
 import { ZSTDDecoder } from 'zstddec'
 import { LruCache } from '../utils/lruCache'
 import { createOssClient } from './ossClient'
-import type { OssClient, OssError } from './ossClient'
+import type { OssClient } from './ossClient'
 import type { ZarrAccessResponse } from './zarrAccessApi'
 
-// ---------- zstd decoder (singleton; WASM is initialized once) ----------
+// ---------- zstd decoder (singleton) ----------
 
 let zstdDecoderPromise: Promise<ZSTDDecoder> | null = null
 
@@ -47,7 +42,7 @@ function getZstdDecoder(): Promise<ZSTDDecoder> {
   return zstdDecoderPromise
 }
 
-// ---------- gzip / deflate decompression (native DecompressionStream) ----------
+// ---------- decompression helpers ----------
 
 async function decompressBytes(payload: Uint8Array, codecName: string): Promise<Uint8Array> {
   const run = async (format: 'gzip' | 'deflate' | 'deflate-raw') => {
@@ -57,8 +52,6 @@ async function decompressBytes(payload: Uint8Array, codecName: string): Promise<
     return new Uint8Array(await new Response(stream).arrayBuffer())
   }
   if (codecName === 'gzip') return run('gzip')
-  // 'zlib' / 'deflate' chunks are raw deflate; fall back to the zlib-wrapped
-  // variant for data that carries the 2-byte zlib header.
   try {
     return await run('deflate-raw')
   } catch {
@@ -66,26 +59,13 @@ async function decompressBytes(payload: Uint8Array, codecName: string): Promise<
   }
 }
 
-// ---------- zarr v3 metadata types (subset) ----------
+// ---------- zarr v3 metadata types ----------
 
 interface ZarrV3ArrayMetadata {
   zarr_format: 3
   node_type: 'array'
   shape: number[]
-  data_type:
-    | 'float32'
-    | 'float64'
-    | 'int32'
-    | 'int64'
-    | 'uint32'
-    | 'uint64'
-    | 'uint8'
-    | 'uint16'
-    | 'int16'
-    | 'uint16'
-    | 'int8'
-    | 'bool'
-    | string
+  data_type: string
   chunk_grid: {
     name: 'regular'
     configuration: { chunk_shape: number[] }
@@ -99,7 +79,6 @@ interface ZarrV3ArrayMetadata {
     configuration?: Record<string, unknown>
   }>
   attributes?: Record<string, unknown>
-  dimension_names?: string[]
   fill_value?: number | null
 }
 
@@ -112,189 +91,568 @@ interface ZarrV3GroupMetadata {
 // ---------- typed array helpers ----------
 
 type DType =
-  | 'float32'
-  | 'float64'
-  | 'int32'
-  | 'uint32'
-  | 'int16'
-  | 'uint16'
-  | 'int8'
-  | 'uint8'
-  | 'uint64'
-  | 'int64'
+  | 'float32' | 'float64' | 'int32' | 'uint32'
+  | 'int16' | 'uint16' | 'int8' | 'uint8'
+  | 'uint64' | 'int64' | '<f4' | '<f8' | '<u4' | '<i8'
 
-function bytesPerElement(dtype: DType): number {
-  switch (dtype) {
-    case 'float32':
-    case 'int32':
-    case 'uint32':
-      return 4
-    case 'float64':
-    case 'int64':
-    case 'uint64':
-      return 8
-    case 'int16':
-    case 'uint16':
-      return 2
-    case 'int8':
-    case 'uint8':
-      return 1
-    default:
-      return 4
+function normalizeDtype(dtype: string): DType {
+  // Handle numpy-style dtype strings
+  const map: Record<string, DType> = {
+    '<f4': 'float32', '<f8': 'float64',
+    '<u4': 'uint32', '<i8': 'int64',
+    '>f4': 'float32', '>f8': 'float64',
+  }
+  return (map[dtype] ?? dtype) as DType
+}
+
+function bytesPerElement(dtype: string): number {
+  const dt = normalizeDtype(dtype)
+  switch (dt) {
+    case 'float32': case 'int32': case 'uint32': return 4
+    case 'float64': case 'int64': case 'uint64': return 8
+    case 'int16': case 'uint16': return 2
+    case 'int8': case 'uint8': return 1
+    default: return 4
   }
 }
 
-function makeTypedArray(
-  dtype: DType,
-  buf: ArrayBuffer,
-): Float32Array | Float64Array | Int32Array | Uint32Array | Int16Array | Uint16Array | Int8Array | Uint8Array | BigInt64Array | BigUint64Array {
-  switch (dtype) {
-    case 'float32':
-      return new Float32Array(buf)
-    case 'float64':
-      return new Float64Array(buf)
-    case 'int32':
-      return new Int32Array(buf)
-    case 'uint32':
-      return new Uint32Array(buf)
-    case 'int16':
-      return new Int16Array(buf)
-    case 'uint16':
-      return new Uint16Array(buf)
-    case 'int8':
-      return new Int8Array(buf)
-    case 'uint8':
-      return new Uint8Array(buf)
-    case 'int64':
-      return new BigInt64Array(buf)
-    case 'uint64':
-      return new BigUint64Array(buf)
+function makeTypedArray(dtype: string, buf: ArrayBuffer) {
+  const dt = normalizeDtype(dtype)
+  switch (dt) {
+    case 'float32': return new Float32Array(buf)
+    case 'float64': return new Float64Array(buf)
+    case 'int32': return new Int32Array(buf)
+    case 'uint32': return new Uint32Array(buf)
+    case 'int16': return new Int16Array(buf)
+    case 'uint16': return new Uint16Array(buf)
+    case 'int8': return new Int8Array(buf)
+    case 'uint8': return new Uint8Array(buf)
+    case 'int64': return new BigInt64Array(buf)
+    case 'uint64': return new BigUint64Array(buf)
   }
 }
 
-// ---------- main store ----------
+// ---------- domain types ----------
+
+export type DataMode = 'continuous' | 'processed'
+
+/** Root attributes from /.zattrs */
+export interface RootAttrs {
+  format: string
+  format_version: string
+  write_state: string
+  coordinate_order: string[]
+  coordinate_base: number
+  spatial_shape: [number, number]
+}
+
+/** Data group attributes from /data/.zattrs */
+export interface DataAttrs {
+  row_axis: 'pixel' | 'ion'
+  encoding: 'continuous' | 'processed'
+}
+
+/** Metadata attributes from /metadata/.zattrs */
+export interface MetadataAttrs {
+  name?: string
+  version?: number
+  spectrum_count_num?: number
+  max_count_of_pixels_x?: number
+  max_count_of_pixels_y?: number
+  pixel_size_horizontal?: number
+  pixel_size_vertical?: number
+  analyzer?: string
+  ionisation_source?: string
+  polarity?: string
+  centroid_spectrum?: boolean
+  profile_spectrum?: boolean
+  continuous?: boolean
+  processed?: boolean
+  ms1_spectrum?: boolean
+  msn_spectrum?: boolean
+  filename?: string
+  [key: string]: unknown
+}
 
 export interface IonImageInfo {
   mzIndex: number
   mz: number
-  chunkIndex: number
-  localIndex: number
+  /** Row-major [height * width] */
+  matrix: Float32Array
   width: number
   height: number
-  /** row-major [H, W] */
-  matrix: Float32Array
 }
 
-export interface DecodedIonImageChunk {
-  chunkIndex: number
-  /** ndim === 3 → [chunkSize, H, W] in one Float32Array (row-major) */
-  data: Float32Array
-  chunkShape: [number, number, number]
-  width: number
-  height: number
-  /** Global mz_axis index for each mz slot in this chunk. */
-  mzIndices: number[]
-  /** mz value for each mz slot in this chunk. */
-  mzValues: number[]
+export interface PixelSpectrum {
+  pixelIndex: number
+  /** 1-based coordinate from axes/coordinates */
+  x: number
+  y: number
+  mz: Float64Array
+  intensity: Float32Array
 }
 
 export interface CacheInfo {
-  maxSize: number
-  size: number
-  keys: (string | number)[]
-  currentChunk: number | null
+  intensityChunkCacheSize: number
+  intensityChunkCacheEntries: number
+  mzChunkCacheSize: number
+  mzChunkCacheEntries: number
 }
 
-export interface ZarrOssStoreOptions {
-  /** ion_images chunk cache size; defaults to 5. */
-  ionChunkCacheSize?: number
-}
-
-interface InFlightEntry {
-  promise: Promise<DecodedIonImageChunk & { fetchMs: number; decodeMs: number }>
-  cached: boolean
-}
+// ---------- main store ----------
 
 export class ZarrOssStore {
   private access: ZarrAccessResponse
   private oss: OssClient
-  private cache: LruCache<number, DecodedIonImageChunk>
-  private inFlight = new Map<number, InFlightEntry>()
-  private currentChunk: number | null = null
 
-  // metadata
-  private ionMeta: ZarrV3ArrayMetadata | null = null
-  private mzMeta: ZarrV3ArrayMetadata | null = null
+  // Mode detection
+  private _dataMode: DataMode | null = null
+  private _rowAxis: 'pixel' | 'ion' | null = null
+
+  // Root attributes
+  private _spatialShape: [number, number] | null = null
+  private coordinateBase: number = 1
+
+  // Array metadata (zarr.json for each array)
+  private intensityMeta: ZarrV3ArrayMetadata | null = null
+  private offsetsMeta: ZarrV3ArrayMetadata | null = null
+  private dataMzMeta: ZarrV3ArrayMetadata | null = null
+  private axesMzMeta: ZarrV3ArrayMetadata | null = null
+  private coordinatesMeta: ZarrV3ArrayMetadata | null = null
   private meanSpectrumMeta: ZarrV3ArrayMetadata | null = null
 
-  // data
-  private mzAxis: Float32Array | Float64Array | null = null
-  private meanSpectrum: Float32Array | Float64Array | null = null
+  // Fully loaded small arrays (cached after first load)
+  private coordinates: Uint32Array | null = null
+  private mzAxis: Float64Array | null = null
+  private _offsets: number[] | null = null   // converted from int64
+  private meanSpectrum: Float32Array | null = null
 
-  constructor(access: ZarrAccessResponse, options: ZarrOssStoreOptions = {}) {
+  // Metadata attrs
+  private _metadataAttrs: MetadataAttrs | null = null
+
+  // Chunk caches for large 1D arrays
+  private intensityChunkCache: LruCache<number, Float32Array>
+  private mzChunkCache: LruCache<number, Float64Array>
+  private inFlightIntensity = new Map<number, Promise<Float32Array>>()
+  private inFlightMz = new Map<number, Promise<Float64Array>>()
+
+  // Derived
+  private totalIntensityPoints: number = 0
+  private totalMzPoints: number = 0
+
+  constructor(
+    access: ZarrAccessResponse,
+    options: { intensityChunkCacheSize?: number; mzChunkCacheSize?: number } = {},
+  ) {
     this.access = access
     this.oss = createOssClient(access)
-    this.cache = new LruCache<number, DecodedIonImageChunk>(options.ionChunkCacheSize ?? 5)
+    this.intensityChunkCache = new LruCache<number, Float32Array>(
+      options.intensityChunkCacheSize ?? 20,
+    )
+    this.mzChunkCache = new LruCache<number, Float64Array>(
+      options.mzChunkCacheSize ?? 5,
+    )
   }
 
-  // ---------- lifecycle ----------
 
+  // ========== public accessors ==========
+
+  get dataMode(): DataMode {
+    if (!this._dataMode) throw new Error('[ZarrOssStore] call init() first')
+    return this._dataMode
+  }
+
+  get rowAxis(): 'pixel' | 'ion' {
+    if (!this._rowAxis) throw new Error('[ZarrOssStore] call init() first')
+    return this._rowAxis
+  }
+
+  get spatialShape(): [number, number] {
+    if (!this._spatialShape) throw new Error('[ZarrOssStore] call init() first')
+    return this._spatialShape
+  }
+
+  get nRows(): number {
+    return this._offsets ? this._offsets.length - 1 : 0
+  }
+
+  get metadataAttrs(): MetadataAttrs | null {
+    return this._metadataAttrs
+  }
+
+  // ========== lifecycle ==========
+
+  /**
+   * 初始化：读取根属性、data 属性、各数组元数据。
+   * 自动判定数据模式（continuous / processed）和行轴（pixel / ion）。
+   *
+   * 属性优先从 zarr.json 的 attributes 字段读取；
+   * 如果不存在才尝试独立 .zattrs 文件（兼容其他 writer）。
+   */
   async init(): Promise<void> {
-    // Read the root zarr.json to confirm this is a group.
-    const rootMeta = await this.readJson<ZarrV3GroupMetadata>('zarr.json')
-    if (rootMeta.zarr_format !== 3 || rootMeta.node_type !== 'group') {
+    // 1) 根 zarr.json：验证 v3 group + 从中提取根属性
+    const rootZarrJson = await this.readJson<ZarrV3GroupMetadata>('zarr.json')
+    if (rootZarrJson.zarr_format !== 3 || rootZarrJson.node_type !== 'group') {
       throw new Error(
-        `[ZarrOssStore] unsupported zarr format/node_type: ${rootMeta.zarr_format}/${rootMeta.node_type}`,
+        `[ZarrOssStore] unsupported root zarr format/node_type: ${rootZarrJson.zarr_format}/${rootZarrJson.node_type}`,
       )
     }
-    this.ionMeta = await this.readJson<ZarrV3ArrayMetadata>('ion_images/zarr.json')
-    this.mzMeta = await this.readJson<ZarrV3ArrayMetadata>('mz_axis/zarr.json')
 
-    this.assertIonImagesMetadata(this.ionMeta)
-    this.assertIsV3Array(this.mzMeta, 'mz_axis')
+    const rootAttrs = rootZarrJson.attributes as unknown as RootAttrs | undefined
+    if (!rootAttrs?.format || !rootAttrs?.spatial_shape) {
+      throw new Error(
+        '[ZarrOssStore] root zarr.json missing required attributes (format, spatial_shape)',
+      )
+    }
+    this.validateRootAttrs(rootAttrs)
+    this._spatialShape = rootAttrs.spatial_shape
+    this.coordinateBase = rootAttrs.coordinate_base
+
+    // 2) data 组属性：优先 zarr.json attributes，其次 .zattrs
+    const dataAttrs = await this.readDataAttrs()
+    this._rowAxis = dataAttrs.row_axis
+    this._dataMode = dataAttrs.encoding
+
+    // 3) 读取各 data 子数组的 zarr.json 元数据
+    this.intensityMeta = await this.readArrayMeta('data/intensity')
+    this.offsetsMeta = await this.readArrayMeta('data/offsets')
+    this.totalIntensityPoints = this.intensityMeta.shape[0]!
+
+    // 5) data/mz 仅 processed 模式存在
+    if (this._dataMode === 'processed') {
+      try {
+        this.dataMzMeta = await this.readArrayMeta('data/mz')
+        this.totalMzPoints = this.dataMzMeta.shape[0]!
+      } catch {
+        throw new Error(
+          '[ZarrOssStore] processed mode requires data/mz array',
+        )
+      }
+    }
+
+    // 6) axes/mz 仅 continuous 模式存在
+    if (this._dataMode === 'continuous') {
+      try {
+        this.axesMzMeta = await this.readArrayMeta('axes/mz')
+      } catch {
+        throw new Error(
+          '[ZarrOssStore] continuous mode requires axes/mz array',
+        )
+      }
+    }
+
+    // 7) axes/coordinates 始终存在
+    this.coordinatesMeta = await this.readArrayMeta('axes/coordinates')
+
+    // 7) metadata 属性（非致命，可能不存在）
+    try {
+      const meta = await this.readJson<ZarrV3GroupMetadata>('metadata/zarr.json')
+      if (meta.attributes) {
+        this._metadataAttrs = meta.attributes as unknown as MetadataAttrs
+      }
+    } catch {
+      // metadata 组可选
+    }
+
+    // 9) stats/mean_spectrum（非致命，可能不存在）
+    try {
+      this.meanSpectrumMeta = await this.readArrayMeta('stats/mean_spectrum')
+    } catch {
+      // mean_spectrum 是可选的统计量
+    }
 
     if (import.meta.env.DEV) {
       console.table({
         bucket: this.access.bucket,
         region: this.access.region,
         folderPath: this.access.folder_path,
-        mzAxisLength: this.mzMeta.shape[0],
-        ionImagesShape: this.ionMeta.shape.join('x'),
-        ionImagesChunkShape: this.ionMeta.chunk_grid.configuration.chunk_shape.join('x'),
-        dtype: this.ionMeta.data_type,
-        codecs: (this.ionMeta.codecs ?? []).map((c) => c.name).join(',') || '(none)',
-        cacheSize: this.cache.maxSize,
+        dataMode: this._dataMode,
+        rowAxis: this._rowAxis,
+        spatialShape: this._spatialShape.join('×'),
+        totalIntensityPoints: this.totalIntensityPoints.toLocaleString(),
+        intensityDtype: this.intensityMeta.data_type,
+        intensityChunkShape: this.intensityMeta.chunk_grid.configuration.chunk_shape.join(','),
+        codecs: (this.intensityMeta.codecs ?? []).map((c) => c.name).join(',') || '(none)',
+        hasMeanSpectrum: !!this.meanSpectrumMeta,
       })
     }
   }
 
-  private assertIsV3Array(meta: ZarrV3ArrayMetadata, label: string) {
-    if (meta.zarr_format !== 3 || meta.node_type !== 'array') {
-      throw new Error(`[ZarrOssStore] ${label}: not a v3 array`)
+  // ========== data loading: common ==========
+
+  /** Load pixel coordinates. Shape (n_pixels, 3), dtype uint32, one-based. */
+  async loadCoordinates(): Promise<Uint32Array> {
+    if (this.coordinates) return this.coordinates
+    if (!this.coordinatesMeta) throw new Error('[ZarrOssStore] call init() first')
+    const ab = await this.fetchArrayFull('axes/coordinates', this.coordinatesMeta)
+    this.coordinates = new Uint32Array(ab)
+    return this.coordinates
+  }
+
+  /** Load shared m/z axis (continuous mode only). Returns null for processed mode. */
+  async loadMzAxis(): Promise<Float64Array | null> {
+    if (this._dataMode === 'processed') return null
+    if (this.mzAxis) return this.mzAxis
+    if (!this.axesMzMeta) throw new Error('[ZarrOssStore] axes/mz metadata not loaded')
+    const ab = await this.fetchArrayFull('axes/mz', this.axesMzMeta)
+    const dtype = this.axesMzMeta.data_type
+    const typed = makeTypedArray(dtype, ab)
+    this.mzAxis =
+      typed instanceof Float64Array
+        ? typed
+        : new Float64Array(typed as ArrayLike<number>)
+    return this.mzAxis
+  }
+
+  /** Load row offsets. Returns number[] (converted from int64). */
+  async loadOffsets(): Promise<number[]> {
+    if (this._offsets) return this._offsets
+    if (!this.offsetsMeta) throw new Error('[ZarrOssStore] call init() first')
+    const ab = await this.fetchArrayFull('data/offsets', this.offsetsMeta)
+    const typed = new BigInt64Array(ab)
+    this._offsets = Array.from(typed, (v) => Number(v))
+    return this._offsets
+  }
+
+  // ========== data loading: continuous mode (ion image + mean spectrum) ==========
+
+  /**
+   * Get a single ion image by m/z axis index.
+   *
+   * For ion-major continuous:
+   *   intensity[offsets[mzIdx] : offsets[mzIdx+1]] has n_pixels values.
+   *   coordinates[j] maps the j-th value to pixel position (x, y).
+   */
+  async getIonImageByMzIndex(mzIndex: number): Promise<IonImageInfo> {
+    if (this._dataMode !== 'continuous') {
+      throw new Error('[ZarrOssStore] getIonImageByMzIndex only available in continuous mode')
     }
-    const unsupported = (meta.codecs ?? []).filter(
-      (c: { name: string }) => !['bytes', 'gzip', 'zlib', 'deflate', 'zstd'].includes(c.name),
-    )
-    if (unsupported.length > 0) {
+
+    const offsets = await this.loadOffsets()
+    const mzAxis = await this.loadMzAxis()
+    if (!mzAxis) throw new Error('[ZarrOssStore] m/z axis not available')
+
+    if (mzIndex < 0 || mzIndex >= offsets.length - 1) {
       throw new Error(
-        `[ZarrOssStore] ${label}: unsupported codec: ${unsupported.map((c) => c.name).join(',')}`,
+        `[ZarrOssStore] mzIndex out of range: ${mzIndex} (total ${offsets.length - 1} ions)`,
       )
+    }
+
+    const [height, width] = this.spatialShape
+    const start = offsets[mzIndex]!
+    const end = offsets[mzIndex + 1]!
+    const nPixels = end - start
+
+    // Read the intensity slice for this ion
+    const slice = await this.readIntensitySlice(start, end)
+
+    // Map to 2D via coordinates
+    const coords = await this.loadCoordinates()
+    const matrix = new Float32Array(height * width)
+    for (let j = 0; j < nPixels; j++) {
+      const x = coords[j * 3]!
+      const y = coords[j * 3 + 1]!
+      // one-based → zero-based
+      const col = x - this.coordinateBase
+      const row = y - this.coordinateBase
+      if (row >= 0 && row < height && col >= 0 && col < width) {
+        matrix[row * width + col] = slice[j]!
+      }
+    }
+
+    return {
+      mzIndex,
+      mz: mzAxis[mzIndex]!,
+      matrix,
+      width,
+      height,
     }
   }
 
-  private assertIonImagesMetadata(meta: ZarrV3ArrayMetadata) {
-    this.assertIsV3Array(meta, 'ion_images')
-    if (meta.shape.length !== 3) {
+  /**
+   * Load pre-computed mean spectrum from stats/mean_spectrum.
+   * Returns null if not available.
+   */
+  async loadMeanSpectrum(): Promise<Float32Array | null> {
+    if (this._dataMode !== 'continuous') return null
+    if (this.meanSpectrum) return this.meanSpectrum
+    if (!this.meanSpectrumMeta) {
+      // Try to read it
+      try {
+        this.meanSpectrumMeta = await this.readArrayMeta('stats/mean_spectrum')
+      } catch {
+        return null
+      }
+    }
+    const ab = await this.fetchArrayFull('stats/mean_spectrum', this.meanSpectrumMeta)
+    const dtype = this.meanSpectrumMeta.data_type
+    const typed = makeTypedArray(dtype, ab)
+    this.meanSpectrum =
+      typed instanceof Float32Array
+        ? typed
+        : new Float32Array(typed as ArrayLike<number>)
+    return this.meanSpectrum
+  }
+
+  // ========== data loading: processed mode (TIC + per-pixel spectrum) ==========
+
+  /**
+   * Compute the TIC (Total Ion Current) image for processed mode.
+   *
+   * For pixel-major processed:
+   *   Each pixel p has intensity[offsets[p]:offsets[p+1]].
+   *   TIC[p] = sum of those intensities.
+   *   Mapped to 2D via coordinates[p].
+   *
+   * This reads the entire intensity array chunk by chunk and accumulates
+   * TIC per pixel in a single pass.
+   */
+  async computeTICImage(): Promise<Float32Array> {
+    if (this._dataMode !== 'processed') {
+      throw new Error('[ZarrOssStore] computeTICImage only available in processed mode')
+    }
+
+    const offsets = await this.loadOffsets()
+    const coords = await this.loadCoordinates()
+    const [height, width] = this.spatialShape
+    const nPixels = offsets.length - 1
+
+    // Accumulate TIC per pixel
+    const ticByPixel = new Float32Array(nPixels)
+
+    // Read intensity in chunks and accumulate
+    const cs = this.intensityMeta!.chunk_grid.configuration.chunk_shape[0]!
+    const totalChunks = Math.ceil(this.totalIntensityPoints / cs)
+
+    let globalOffset = 0 // current position in the logical intensity array
+    for (let ci = 0; ci < totalChunks; ci++) {
+      const chunk = await this.getIntensityChunk(ci)
+      const chunkStart = ci * cs
+      const chunkEnd = Math.min(chunkStart + cs, this.totalIntensityPoints)
+
+      for (let i = 0; i < chunk.length && chunkStart + i < chunkEnd; i++) {
+        const globalIdx = chunkStart + i
+        // Find which pixel this value belongs to using the offsets array
+        // Advance globalOffset until offsets[globalOffset+1] > globalIdx
+        while (globalOffset < nPixels && offsets[globalOffset + 1]! <= globalIdx) {
+          globalOffset++
+        }
+        if (globalOffset < nPixels) {
+          ticByPixel[globalOffset]! += chunk[i]!
+        }
+      }
+    }
+
+    // Map TIC values to 2D image
+    const matrix = new Float32Array(height * width)
+    for (let p = 0; p < nPixels; p++) {
+      const x = coords[p * 3]!
+      const y = coords[p * 3 + 1]!
+      const col = x - this.coordinateBase
+      const row = y - this.coordinateBase
+      if (row >= 0 && row < height && col >= 0 && col < width) {
+        matrix[row * width + col] = ticByPixel[p]!
+      }
+    }
+
+    return matrix
+  }
+
+  /**
+   * Get the spectrum for a single pixel in processed mode.
+   *
+   * For pixel-major processed:
+   *   mz = data_mz[offsets[p]:offsets[p+1]]
+   *   intensity = data_intensity[offsets[p]:offsets[p+1]]
+   */
+  async getPixelSpectrum(pixelIndex: number): Promise<PixelSpectrum | null> {
+    if (this._dataMode !== 'processed') {
+      throw new Error('[ZarrOssStore] getPixelSpectrum only available in processed mode')
+    }
+
+    const offsets = await this.loadOffsets()
+    const coords = await this.loadCoordinates()
+    const nPixels = offsets.length - 1
+
+    if (pixelIndex < 0 || pixelIndex >= nPixels) {
       throw new Error(
-        `[ZarrOssStore] ion_images: expected ndim=3 [nMz,H,W], got shape=[${meta.shape.join(',')}]`,
+        `[ZarrOssStore] pixelIndex out of range: ${pixelIndex} (total ${nPixels} pixels)`,
       )
+    }
+
+    const start = offsets[pixelIndex]!
+    const end = offsets[pixelIndex + 1]!
+    if (start === end) return null // empty spectrum
+
+    // Read intensity and mz slices in parallel
+    const [intensitySlice, mzSlice] = await Promise.all([
+      this.readIntensitySlice(start, end),
+      this.readMzSlice(start, end),
+    ])
+
+    const x = coords[pixelIndex * 3]!
+    const y = coords[pixelIndex * 3 + 1]!
+
+    return {
+      pixelIndex,
+      x,
+      y,
+      mz: mzSlice,
+      intensity: intensitySlice,
     }
   }
 
-  // ---------- OSS read helpers ----------
+  /** Find the pixel index closest to a 2D (col, row) position (zero-based). */
+  async findPixelByPosition(
+    col: number,
+    row: number,
+    tolerance: number = 1.5,
+  ): Promise<number> {
+    const coords = await this.loadCoordinates()
+    const nPixels = coords.length / 3
+    let bestIdx = -1
+    let bestDist = Infinity
+
+    for (let p = 0; p < nPixels; p++) {
+      const cx = coords[p * 3]!
+      const cy = coords[p * 3 + 1]!
+      const px = cx - this.coordinateBase
+      const py = cy - this.coordinateBase
+      const dist = Math.sqrt((px - col) ** 2 + (py - row) ** 2)
+      if (dist < bestDist) {
+        bestDist = dist
+        bestIdx = p
+      }
+    }
+
+    return bestDist <= tolerance ? bestIdx : -1
+  }
+
+  // ========== backward-compat helpers ==========
+
+  /**
+   * Returns [nMz, height, width] for continuous mode.
+   * Used by existing components that expect the old ion shape format.
+   */
+  getIonShape(): number[] | null {
+    if (this._dataMode !== 'continuous') return null
+    if (!this._spatialShape) return null
+    const offsetsLen = this._offsets ? this._offsets.length - 1 : 0
+    return [offsetsLen, this._spatialShape[0], this._spatialShape[1]]
+  }
+
+  getCacheInfo(): CacheInfo {
+    return {
+      intensityChunkCacheSize: this.intensityChunkCache.maxSize,
+      intensityChunkCacheEntries: this.intensityChunkCache.size,
+      mzChunkCacheSize: this.mzChunkCache.maxSize,
+      mzChunkCacheEntries: this.mzChunkCache.size,
+    }
+  }
+
+  // ========== internal: OSS key helpers ==========
 
   private key(relativePath: string): string {
-    // folder_path usually ends with "/"
     const root = this.access.folder_path
     const rel = relativePath.replace(/^\/+/, '')
     return root.endsWith('/') ? `${root}${rel}` : `${root}/${rel}`
@@ -313,50 +671,213 @@ export class ZarrOssStore {
     }
   }
 
-  // ---------- chunk key encoding ----------
-
-  /**
-   * Compute the OSS object key for ion_images chunk #chunkIndex.
-   *
-   * Zarr v3 default chunk key encoding:
-   *   ["c", ...chunkCoords].join(separator)   (separator defaults to "/")
-   * → for chunkIndex=5 with H/W = 0: "ion_images/c/5/0/0"
-   */
-  private computeChunkKey(chunkIndex: number): string {
-    if (!this.ionMeta) throw new Error('[ZarrOssStore] ionMeta not loaded, call init() first')
-    const enc = this.ionMeta.chunk_key_encoding
-    if (enc.name !== 'default') {
-      throw new Error(`[ZarrOssStore] unsupported chunk key encoding: ${enc.name}`)
-    }
-    const sep = enc.configuration?.separator ?? '/'
-    // Full chunk: mz dim = chunkIndex, H/W dims = 0.
-    const inner = `c${sep}${chunkIndex}${sep}0${sep}0`
-    return `ion_images/${inner}`
+  /** Read a zarr v3 array's zarr.json */
+  private async readArrayMeta(arrayPath: string): Promise<ZarrV3ArrayMetadata> {
+    const meta = await this.readJson<ZarrV3ArrayMetadata>(`${arrayPath}/zarr.json`)
+    this.assertV3Array(meta, arrayPath)
+    return meta
   }
 
-  // ---------- decode chunk bytes ----------
+  /** Read data group attributes. Tries .zattrs first, then falls back to zarr.json attributes. */
+  private async readDataAttrs(): Promise<DataAttrs> {
+    const meta = await this.readJson<ZarrV3GroupMetadata>('data/zarr.json')
+    if (!meta.attributes?.row_axis || !meta.attributes?.encoding) {
+      throw new Error(
+        '[ZarrOssStore] data/zarr.json missing required attributes (row_axis, encoding)',
+      )
+    }
+    return meta.attributes as unknown as DataAttrs
+  }
 
-  private async decodeIonImageChunk(
+  private validateRootAttrs(attrs: RootAttrs): void {
+    if (attrs.format !== 'massflow.msi_zarr') {
+      throw new Error(
+        `[ZarrOssStore] unsupported format: ${attrs.format}, expected massflow.msi_zarr`,
+      )
+    }
+    if (attrs.write_state !== 'complete') {
+      throw new Error(
+        `[ZarrOssStore] dataset write_state is "${attrs.write_state}", expected "complete"`,
+      )
+    }
+    if (!attrs.spatial_shape || attrs.spatial_shape.length !== 2) {
+      throw new Error(
+        `[ZarrOssStore] invalid spatial_shape: ${JSON.stringify(attrs.spatial_shape)}`,
+      )
+    }
+  }
+
+  private assertV3Array(meta: ZarrV3ArrayMetadata, label: string): void {
+    if (meta.zarr_format !== 3 || meta.node_type !== 'array') {
+      throw new Error(`[ZarrOssStore] ${label}: not a v3 array`)
+    }
+    const unsupported = (meta.codecs ?? []).filter(
+      (c) => !['bytes', 'gzip', 'zlib', 'deflate', 'zstd'].includes(c.name),
+    )
+    if (unsupported.length > 0) {
+      throw new Error(
+        `[ZarrOssStore] ${label}: unsupported codec: ${unsupported.map((c) => c.name).join(',')}`,
+      )
+    }
+  }
+
+  // ========== internal: chunk reading ==========
+
+  /**
+   * Read a slice [start, end) from the 1D intensity array.
+   * Uses chunk caching and in-flight deduplication.
+   */
+  private async readIntensitySlice(start: number, end: number): Promise<Float32Array> {
+    if (!this.intensityMeta) throw new Error('[ZarrOssStore] call init() first')
+    return this.read1DSlice(
+      'data/intensity',
+      this.intensityMeta,
+      start,
+      end,
+      this.intensityChunkCache,
+      this.inFlightIntensity,
+    ) as Promise<Float32Array>
+  }
+
+  /**
+   * Read a slice [start, end) from the 1D data/mz array.
+   */
+  private async readMzSlice(start: number, end: number): Promise<Float64Array> {
+    if (!this.dataMzMeta) throw new Error('[ZarrOssStore] data/mz not available')
+    return this.read1DSlice(
+      'data/mz',
+      this.dataMzMeta,
+      start,
+      end,
+      this.mzChunkCache,
+      this.inFlightMz,
+    ) as Promise<Float64Array>
+  }
+
+  /**
+   * General-purpose 1D array slice reader with chunk caching.
+   */
+  private async read1DSlice(
+    arrayPath: string,
+    meta: ZarrV3ArrayMetadata,
+    start: number,
+    end: number,
+    cache: LruCache<number, Float32Array | Float64Array>,
+    inFlight: Map<number, Promise<Float32Array | Float64Array>>,
+  ): Promise<Float32Array | Float64Array> {
+    if (start >= end) {
+      const Ctor = normalizeDtype(meta.data_type) === 'float64' ? Float64Array : Float32Array
+      return new Ctor(0)
+    }
+
+    const cs = meta.chunk_grid.configuration.chunk_shape[0]!
+    const startChunk = Math.floor(start / cs)
+    const endChunk = Math.floor((end - 1) / cs)
+    const bpe = bytesPerElement(meta.data_type)
+    const isFloat64 = bpe === 8
+
+    const result = isFloat64
+      ? new Float64Array(end - start)
+      : new Float32Array(end - start)
+    let resultOffset = 0
+
+    for (let ci = startChunk; ci <= endChunk; ci++) {
+      const chunk = await this.getOrFetchChunk(arrayPath, meta, ci, cache, inFlight)
+      const chunkStart = ci * cs
+
+      const sliceStart = Math.max(start - chunkStart, 0)
+      const sliceEnd = Math.min(end - chunkStart, chunk.length)
+      const len = sliceEnd - sliceStart
+
+      if (len > 0) {
+        ;(result as Float32Array).set(chunk.subarray(sliceStart, sliceEnd), resultOffset)
+        resultOffset += len
+      }
+    }
+
+    return result
+  }
+
+  /**
+   * Get a single decoded chunk, using cache + in-flight deduplication.
+   */
+  private async getOrFetchChunk(
+    arrayPath: string,
+    meta: ZarrV3ArrayMetadata,
+    chunkIndex: number,
+    cache: LruCache<number, Float32Array | Float64Array>,
+    inFlight: Map<number, Promise<Float32Array | Float64Array>>,
+  ): Promise<Float32Array | Float64Array> {
+    // Check cache
+    const cached = cache.get(chunkIndex)
+    if (cached) return cached
+
+    // Check in-flight
+    const inflight = inFlight.get(chunkIndex)
+    if (inflight) return inflight
+
+    // Fetch
+    const promise = this.fetchAndDecode1DChunk(arrayPath, meta, chunkIndex)
+    inFlight.set(chunkIndex, promise)
+    try {
+      const chunk = await promise
+      cache.set(chunkIndex, chunk)
+      return chunk
+    } finally {
+      inFlight.delete(chunkIndex)
+    }
+  }
+
+  /**
+   * Fetch and decode a single chunk from a 1D zarr array.
+   */
+  private async fetchAndDecode1DChunk(
+    arrayPath: string,
+    meta: ZarrV3ArrayMetadata,
+    chunkIndex: number,
+  ): Promise<Float32Array | Float64Array> {
+    const chunkKey = this.compute1DChunkKey(meta, chunkIndex)
+    const relKey = `${arrayPath}/${chunkKey}`
+    const key = this.key(relKey)
+    const raw = await this.oss.getObjectArrayBuffer(key)
+
+    return this.decode1DChunk(meta, chunkIndex, raw)
+  }
+
+  /**
+   * Compute chunk key for a 1D array using zarr v3 default encoding.
+   * For 1D: "c/0", "c/1", "c/2", ...
+   */
+  private compute1DChunkKey(meta: ZarrV3ArrayMetadata, chunkIndex: number): string {
+    const enc = meta.chunk_key_encoding
+    if (enc.name !== 'default') {
+      throw new Error(
+        `[ZarrOssStore] unsupported chunk key encoding: ${enc.name}`,
+      )
+    }
+    const sep = enc.configuration?.separator ?? '/'
+    return `c${sep}${chunkIndex}`
+  }
+
+  /**
+   * Decode a single 1D chunk: decompress, create typed array, normalize to Float32/64.
+   */
+  private async decode1DChunk(
+    meta: ZarrV3ArrayMetadata,
     chunkIndex: number,
     raw: ArrayBuffer,
-  ): Promise<DecodedIonImageChunk> {
-    if (!this.ionMeta) throw new Error('[ZarrOssStore] ionMeta not loaded')
-    const dtype = this.ionMeta.data_type as DType
-    // Copy the metadata chunk shape — edge chunks may have fewer planes
-    // and we mutate the local copy, never the shared metadata.
-    const chunkShape = [...this.ionMeta.chunk_grid.configuration.chunk_shape] as [
-      number,
-      number,
-      number,
-    ]
-    const [cs, h, w] = chunkShape
+  ): Promise<Float32Array | Float64Array> {
+    const dtype = normalizeDtype(meta.data_type)
+    const cs = meta.chunk_grid.configuration.chunk_shape[0]!
+    const totalLen = meta.shape[0]!
+    const bpe = bytesPerElement(meta.data_type)
+    const isFloat64 = bpe === 8
 
     let payload: Uint8Array = new Uint8Array(raw)
 
-    // 1) Decompress bytes-to-bytes codec (gzip / zlib / deflate / zstd).
-    //    Array-to-bytes codecs like "bytes" are no-ops here.
-    const bytesCodec = (this.ionMeta.codecs ?? []).find(
-      (c: { name: string }) => ['gzip', 'zlib', 'deflate', 'zstd'].includes(c.name),
+    // Decompress
+    const bytesCodec = (meta.codecs ?? []).find(
+      (c) => ['gzip', 'zlib', 'deflate', 'zstd'].includes(c.name),
     )
     if (bytesCodec) {
       payload =
@@ -365,129 +886,85 @@ export class ZarrOssStore {
           : await decompressBytes(payload, bytesCodec.name)
     }
 
-    // 2) Verify byte length.
-    const bpe = bytesPerElement(dtype)
-    const gotBytes = payload.byteLength
-    if (bpe * cs * h * w !== gotBytes) {
-      // Partial chunks at the mz boundary may have fewer than `cs` planes; allow that.
-      const actualCs = Math.floor(gotBytes / (bpe * h * w))
-      if (actualCs <= 0 || actualCs > cs) {
+    // Handle edge chunk (may be smaller than cs)
+    const chunkStart = chunkIndex * cs
+    const expectedElements = Math.min(cs, totalLen - chunkStart)
+    const expectedBytes = expectedElements * bpe
+    let actualBytes = payload.byteLength
+
+    if (actualBytes !== expectedBytes) {
+      // Truncate or handle mismatch gracefully
+      const maxElements = Math.floor(actualBytes / bpe)
+      if (maxElements <= 0) {
         throw new Error(
-          `[ZarrOssStore] chunk size mismatch at chunkIndex=${chunkIndex}: ` +
-            `expected ${bpe * cs * h * w} bytes, got ${gotBytes} bytes`,
+          `[ZarrOssStore] empty chunk at chunkIndex=${chunkIndex}`,
         )
       }
-      // Edge chunk: replace the effective cs with the actual one.
-      ;(chunkShape as number[])[0] = actualCs
+      actualBytes = maxElements * bpe
     }
 
-    // 3) Wrap into an ArrayBuffer to rebuild the typed array
-    // (the decoder output may be a Uint8Array whose byteOffset is non-zero).
+    // Create typed array
     const ab = payload.buffer.slice(
       payload.byteOffset,
-      payload.byteOffset + payload.byteLength,
+      payload.byteOffset + actualBytes,
     )
-    const typed = makeTypedArray(dtype, ab as ArrayBuffer) as Float32Array | Float64Array
-    // Normalize to Float32Array for downstream consumers.
-    const normalized = typed instanceof Float32Array ? typed : Float32Array.from(typed as Float64Array)
+    const typed = makeTypedArray(meta.data_type, ab as ArrayBuffer)
 
-    // 4) Compute global mz_axis index and mz value for each plane in this chunk.
-    const mzStart = chunkIndex * cs
-    const actualCs = (chunkShape as number[])[0]!
-    const mzIndices: number[] = []
-    const mzValues: number[] = []
-    if (this.mzAxis) {
-      for (let i = 0; i < actualCs; i++) {
-        const gi = mzStart + i
-        if (gi < this.mzAxis.length) {
-          mzIndices.push(gi)
-          mzValues.push(this.mzAxis[gi]!)
-        }
-      }
-    }
-
-    return {
-      chunkIndex,
-      data: normalized,
-      chunkShape: [actualCs, h, w],
-      width: w,
-      height: h,
-      mzIndices,
-      mzValues,
-    }
-  }
-
-  // ---------- public API ----------
-
-  async loadMzAxis(): Promise<Float32Array | Float64Array> {
-    if (this.mzAxis) return this.mzAxis
-    if (!this.mzMeta) throw new Error('[ZarrOssStore] call init() first')
-    const ab = await this.fetchArrayFull('mz_axis', this.mzMeta)
-    const dtype = this.mzMeta.data_type as DType
-    const typed = makeTypedArray(dtype, ab)
-    this.mzAxis =
-      typed instanceof Float32Array || typed instanceof Float64Array
+    // Normalize to Float32Array or Float64Array
+    if (isFloat64) {
+      return typed instanceof Float64Array
         ? typed
-        : Float64Array.from(typed as ArrayLike<number>)
-    return this.mzAxis
-  }
-
-  async loadMeanSpectrum(): Promise<Float32Array | Float64Array> {
-    if (this.meanSpectrum) return this.meanSpectrum
-    if (!this.meanSpectrumMeta) {
-      this.meanSpectrumMeta = await this.readJson<ZarrV3ArrayMetadata>('mean_spectrum/zarr.json')
-      this.assertIsV3Array(this.meanSpectrumMeta, 'mean_spectrum')
+        : new Float64Array(typed as ArrayLike<number>)
     }
-    const ab = await this.fetchArrayFull('mean_spectrum', this.meanSpectrumMeta)
-    const dtype = this.meanSpectrumMeta.data_type as DType
-    const typed = makeTypedArray(dtype, ab)
-    this.meanSpectrum =
-      typed instanceof Float32Array || typed instanceof Float64Array
-        ? typed
-        : Float64Array.from(typed as ArrayLike<number>)
-    return this.meanSpectrum
+    return typed instanceof Float32Array
+      ? typed
+      : new Float32Array(typed as ArrayLike<number>)
   }
 
   /**
-   * General-purpose: read a small 1D/2D array in one shot. Downloads every
-   * chunk and concatenates them. Only used for small arrays like mz_axis.
+   * Read a small array in full (for metadata arrays like offsets, coordinates, mz_axis).
+   * Downloads all chunks and concatenates.
    */
   private async fetchArrayFull(
-    relPath: string,
+    arrayPath: string,
     meta: ZarrV3ArrayMetadata,
   ): Promise<ArrayBuffer> {
-    const total = meta.shape.reduce((a, b) => a * b, 1)
-    const bpe = bytesPerElement(meta.data_type as DType)
+    const shape = meta.shape
+    const total = shape.reduce((a, b) => a * b, 1)
+    const bpe = bytesPerElement(meta.data_type)
     const out = new Uint8Array(total * bpe)
 
     const chunkShape = meta.chunk_grid.configuration.chunk_shape
-    const dims = meta.shape.length
-    const totalChunks: number[] = meta.shape.map((s, i) => Math.ceil(s / chunkShape[i]!))
+    const ndim = shape.length
 
-    const chunkIndices: number[][] = [[]]
-    for (let d = 0; d < dims; d++) {
-      const next: number[][] = []
-      for (const prefix of chunkIndices) {
-        for (let i = 0; i < totalChunks[d]!; i++) next.push([...prefix, i])
+    // Generate all chunk indices
+    const totalChunksPerDim: number[] = shape.map((s, i) =>
+      Math.ceil(s / chunkShape[i]!),
+    )
+
+    const chunkIndices: number[][] = []
+    const generateIndices = (dim: number, prefix: number[]) => {
+      if (dim === ndim) {
+        chunkIndices.push([...prefix])
+        return
       }
-      chunkIndices.length = 0
-      chunkIndices.push(...next)
+      for (let i = 0; i < totalChunksPerDim[dim]!; i++) {
+        prefix.push(i)
+        generateIndices(dim + 1, prefix)
+        prefix.pop()
+      }
     }
+    generateIndices(0, [])
 
+    // Fetch and assemble each chunk
     for (const ci of chunkIndices) {
-      const enc = meta.chunk_key_encoding
-      let chunkKey: string
-      if (enc.name === 'default') {
-        const sep = enc.configuration?.separator ?? '/'
-        chunkKey = ['c', ...ci].join(sep)
-      } else {
-        throw new Error(`[ZarrOssStore] unsupported chunk key encoding: ${enc.name}`)
-      }
-      const chunkRelKey = `${relPath}/${chunkKey}`
+      const chunkKey = this.computeNDChunkKey(meta, ci)
+      const chunkRelKey = `${arrayPath}/${chunkKey}`
       const raw = await this.oss.getObjectArrayBuffer(this.key(chunkRelKey))
+
       let payload: Uint8Array = new Uint8Array(raw)
       const bytesCodec = (meta.codecs ?? []).find(
-        (c: { name: string }) => ['gzip', 'zlib', 'deflate', 'zstd'].includes(c.name),
+        (c) => ['gzip', 'zlib', 'deflate', 'zstd'].includes(c.name),
       )
       if (bytesCodec) {
         payload =
@@ -495,158 +972,63 @@ export class ZarrOssStore {
             ? (await getZstdDecoder()).decode(payload)
             : await decompressBytes(payload, bytesCodec.name)
       }
-      // Compute this chunk's byte offset inside `out`.
+
+      // Compute byte offset in output
       const chunkStart: number[] = ci.map((c, d) => c * chunkShape[d]!)
-      const chunkSize: number[] = ci.map((c, d) => {
-        const start = c * chunkShape[d]!
-        return Math.min(chunkShape[d]!, meta.shape[d]! - start)
-      })
-      // Simplified: only 1D is supported by this function. 2D+ is not handled here.
-      if (dims === 1) {
-        const start = chunkStart[0]! * bpe
-        out.set(payload.subarray(0, chunkSize[0]! * bpe), start)
-      } else {
-        // 2D: copy row by row.
-        if (dims === 2) {
-          const [ch, cw] = chunkShape
-          const [h, w] = chunkSize
-          for (let r = 0; r < h!; r++) {
-            const srcOff = r * ch! * bpe
-            const dstOff = ((chunkStart[0]! + r) * meta.shape[1]! + chunkStart[1]!) * bpe
-            out.set(payload.subarray(srcOff, srcOff + w! * bpe), dstOff)
-          }
-        } else {
-          throw new Error(
-            `[ZarrOssStore] fetchArrayFull only supports 1D/2D, got ndim=${dims}`,
-          )
+      const chunkSize: number[] = ci.map((c, d) =>
+        Math.min(chunkShape[d]!, shape[d]! - c * chunkShape[d]!),
+      )
+
+      if (ndim === 1) {
+        const byteOff = chunkStart[0]! * bpe
+        out.set(payload.subarray(0, chunkSize[0]! * bpe), byteOff)
+      } else if (ndim === 2) {
+        // 源行跨步 = chunk 一行有几个元素（chunkShape[1]），不是 chunkShape[0]（行数）
+        const srcRowElems = chunkShape[1]!
+        const [h, w] = chunkSize
+        const [dstStride] = shape.slice(1)
+        for (let r = 0; r < h!; r++) {
+          const srcOff = r * srcRowElems * bpe
+          const dstOff =
+            ((chunkStart[0]! + r) * dstStride! + chunkStart[1]!) * bpe
+          out.set(payload.subarray(srcOff, srcOff + w! * bpe), dstOff)
         }
+      } else {
+        throw new Error(
+          `[ZarrOssStore] fetchArrayFull only supports 1D/2D, got ndim=${ndim}`,
+        )
       }
     }
 
     return out.buffer.slice(out.byteOffset, out.byteOffset + out.byteLength)
   }
 
-  /**
-   * Core entry point: lazily fetch a single ion image.
-   * Automatically goes through the LRU cache; concurrent requests for the
-   * same chunk share a single in-flight Promise.
-   */
-  async getIonImageByMzIndex(mzIndex: number): Promise<IonImageInfo> {
-    if (!this.ionMeta) throw new Error('[ZarrOssStore] call init() first')
-    if (!this.mzAxis) await this.loadMzAxis()
-
-    const totalMz = this.ionMeta.shape[0]!
-    if (mzIndex < 0 || mzIndex >= totalMz) {
+  /** Compute chunk key for N-D arrays */
+  private computeNDChunkKey(
+    meta: ZarrV3ArrayMetadata,
+    chunkIndices: number[],
+  ): string {
+    const enc = meta.chunk_key_encoding
+    if (enc.name !== 'default') {
       throw new Error(
-        `[ZarrOssStore] mzIndex out of range: ${mzIndex} (total ${totalMz})`,
+        `[ZarrOssStore] unsupported chunk key encoding: ${enc.name}`,
       )
     }
-    const chunkShape = this.ionMeta.chunk_grid.configuration.chunk_shape
-    const cs = chunkShape[0]!
-    const chunkIndex = Math.floor(mzIndex / cs)
-    const localIndex = mzIndex % cs
+    const sep = enc.configuration?.separator ?? '/'
+    return `c${sep}${chunkIndices.join(sep)}`
+  }
 
-    const t0 = performance.now()
-    const cached = this.cache.get(chunkIndex)
-    let chunk: DecodedIonImageChunk
-    let chunkCacheHit = false
-    let fetchMs = 0
-    let decodeMs = 0
-    if (cached) {
-      chunk = cached
-      chunkCacheHit = true
-    } else {
-      const inflight = this.inFlight.get(chunkIndex)
-      if (inflight) {
-        const decoded = await inflight.promise
-        chunk = decoded
-        chunkCacheHit = inflight.cached
-        fetchMs = decoded.fetchMs
-        decodeMs = decoded.decodeMs
-      } else {
-        const p = this.fetchAndDecodeChunk(chunkIndex)
-        this.inFlight.set(chunkIndex, { promise: p, cached: false })
-        let decoded: DecodedIonImageChunk & { fetchMs: number; decodeMs: number }
-        try {
-          decoded = await p
-          chunk = decoded
-        } catch (err) {
-          this.inFlight.delete(chunkIndex)
-          throw err
-        }
-        this.inFlight.delete(chunkIndex)
-        this.cache.set(chunkIndex, chunk)
-        fetchMs = decoded.fetchMs
-        decodeMs = decoded.decodeMs
-      }
-    }
-
-    this.currentChunk = chunkIndex
-
-    const [, h, w] = chunk.chunkShape
-    const planeSize = h * w
-    // Return a subarray VIEW (no copy): the caller (loadIonSliceSum) accumulates
-    // it into a target matrix immediately, so the view stays valid for the
-    // duration of the call and the chunk cannot be evicted by LRU mid-use.
-    const matrix = chunk.data.subarray(localIndex * planeSize, (localIndex + 1) * planeSize)
-
-    const info: IonImageInfo = {
-      mzIndex,
-      mz: this.mzAxis ? (this.mzAxis[mzIndex] as number) : NaN,
+  /**
+   * Get a single intensity chunk (public for cache inspection).
+   */
+  private async getIntensityChunk(chunkIndex: number): Promise<Float32Array> {
+    if (!this.intensityMeta) throw new Error('[ZarrOssStore] call init() first')
+    return (await this.getOrFetchChunk(
+      'data/intensity',
+      this.intensityMeta,
       chunkIndex,
-      localIndex,
-      width: w,
-      height: h,
-      matrix,
-    }
-
-    return info
-  }
-
-  async getIonImageChunk(chunkIndex: number): Promise<DecodedIonImageChunk> {
-    const cached = this.cache.get(chunkIndex)
-    if (cached) return cached
-    const inflight = this.inFlight.get(chunkIndex)
-    if (inflight) return inflight.promise
-    const p = this.fetchAndDecodeChunk(chunkIndex)
-    this.inFlight.set(chunkIndex, { promise: p, cached: false })
-    try {
-      const chunk = await p
-      this.inFlight.delete(chunkIndex)
-      this.cache.set(chunkIndex, chunk)
-      return chunk
-    } catch (err) {
-      this.inFlight.delete(chunkIndex)
-      throw err
-    }
-  }
-
-  private async fetchAndDecodeChunk(chunkIndex: number): Promise<DecodedIonImageChunk & { fetchMs: number; decodeMs: number }> {
-    const relKey = this.computeChunkKey(chunkIndex)
-    const key = this.key(relKey)
-    const tFetch0 = performance.now()
-    const raw = await this.oss.getObjectArrayBuffer(key)
-    const fetchMs = performance.now() - tFetch0
-    const tDecode0 = performance.now()
-    const decoded = await this.decodeIonImageChunk(chunkIndex, raw)
-    const decodeMs = performance.now() - tDecode0
-    return Object.assign(decoded, { fetchMs, decodeMs })
-  }
-
-  getCacheInfo(): CacheInfo {
-    return {
-      maxSize: this.cache.maxSize,
-      size: this.cache.size,
-      keys: this.cache.keys(),
-      currentChunk: this.currentChunk,
-    }
-  }
-
-  getIonShape(): number[] | null {
-    return this.ionMeta?.shape ?? null
-  }
-
-  getIonChunkShape(): number[] | null {
-    return this.ionMeta?.chunk_grid.configuration.chunk_shape ?? null
+      this.intensityChunkCache,
+      this.inFlightIntensity,
+    )) as Float32Array
   }
 }

--- a/src/shared/config/defaults.ts
+++ b/src/shared/config/defaults.ts
@@ -21,8 +21,10 @@ export const OSS_UPLOAD = {
 
 /** Zarr OSS Store 配置 */
 export const ZARR_STORE = {
-  /** ion_images chunk 缓存数量（LRU） */
-  ionChunkCacheSize: 5,
+  /** intensity chunk 缓存数量（LRU） */
+  intensityChunkCacheSize: 20,
+  /** data/mz chunk 缓存数量（LRU），仅 processed 模式使用 */
+  mzChunkCacheSize: 5,
   /** 默认 m/z 容差 */
   defaultMzTolerance: 0.05,
 } as const

--- a/src/views/MyDatasets.vue
+++ b/src/views/MyDatasets.vue
@@ -84,6 +84,7 @@
           @view-overview="viewOverview"
           @download="handleDownloadRaw"
           @delete="handleDelete"
+          @explore="handleExplore"
           @change-size="changeSize"
           @go-to-page="goToPage"
         >
@@ -186,6 +187,10 @@ const handleDelete = async (id?: string) => {
   if (!id) return
   datasetToDelete.value = id
   isDeleteModalOpen.value = true
+}
+
+const handleExplore = (_id?: string) => {
+  // TODO: 后续实现
 }
 
 const confirmDelete = async () => {

--- a/src/views/PublicDatasets.vue
+++ b/src/views/PublicDatasets.vue
@@ -46,6 +46,10 @@ const viewOverview = (fileId: string) => {
   router.push({ name: 'DatasetOverview', state: { fileId, source: 'public' } })
 }
 
+const handleExplore = (_id?: string) => {
+  // TODO: 后续实现
+}
+
 // (download logic handled by composable above)
 
 const { handleSearch, handleStatusFilter, handleApplyFilters, goToPage, changeSize } =
@@ -85,6 +89,7 @@ const { handleSearch, handleStatusFilter, handleApplyFilters, goToPage, changeSi
           :packingIds="packingIds"
           @view-overview="viewOverview"
           @download="handleDownloadRaw"
+          @explore="handleExplore"
           @change-size="changeSize"
           @go-to-page="goToPage"
         >

--- a/src/views/workspace/ResultDetail.vue
+++ b/src/views/workspace/ResultDetail.vue
@@ -6,12 +6,20 @@ import ResultHeader from '@/features/workspace/results/components/visuals/Result
 import IonImageSection from '@/features/workspace/results/components/IonImageSection.vue'
 import SpectrumSection from '@/features/workspace/results/components/SpectrumSection.vue'
 import OverlayControls from '@/features/workspace/results/components/OverlayControls.vue'
-import { useZarrIonImage } from '@/features/workspace/results/composables/useZarrIonImage'
+import {
+  useZarrIonImage,
+  ticMatrix,
+  pixelSpectrum,
+  loadPixelSpectrum,
+  dataModeRef,
+} from '@/features/workspace/results/composables/useZarrIonImage'
 import { useDisplayRange } from '@/features/workspace/results/composables/useDisplayRange'
 import { useOverlayData } from '@/features/workspace/results/composables/useOverlayData'
 import { useResultROI } from '@/features/workspace/results/composables/useResultROI'
 import { useResultMeta } from '@/features/workspace/results/composables/useResultMeta'
+import { getSharedZarrContext } from '@/features/workspace/results/composables/useZarrIonImage'
 import { ZARR_STORE } from '@/shared/config/defaults'
+import type { DataMode } from '@/services/zarrOssStore'
 
 interface ResultDetailState {
   runId?: string
@@ -27,10 +35,28 @@ const state = history.state as ResultDetailState | null
 const runId = computed(() => state?.runId != null ? String(state.runId) : '')
 const isStale = computed(() => state?.runId == null)
 
-const { datasetName, analyzer, ionSource, pixelSize, polarity, spectrumMode, storageMode, status, methods } = useResultMeta(runId)
+// ---- 元数据 ----
+
+const {
+  datasetName,
+  analyzer,
+  ionSource,
+  pixelSize,
+  polarity,
+  spectrumMode,
+  storageMode,
+  status,
+  methods,
+  dataMode: metaDataMode,
+} = useResultMeta(runId)
+
+// ---- 可视化参数 ----
+
 const colormap = ref('inferno')
 const intensityScale = ref('linear')
 const gamma = ref(1)
+
+// ---- Zarr 数据加载 ----
 
 const zarr = useZarrIonImage()
 const {
@@ -41,11 +67,25 @@ const {
   ionCols,
   ionRows,
   onSpectrumClickByIndex,
+  isContinuous,
+  isProcessed,
 } = zarr
+
+// 当前数据模式
+const dataMode = computed<DataMode | null>(() => dataModeRef.value)
+
+// processed 模式下的图像矩阵（TIC）
+const currentIonMatrix = computed(() =>
+  isProcessed.value ? ticMatrix.value : ionMatrix.value,
+)
+
+// ---- 初始化 ----
 
 watch(runId, (id) => {
   zarr.init(id)
 }, { immediate: true })
+
+// ---- 显示范围 ----
 
 const {
   globalMin,
@@ -65,7 +105,9 @@ const {
   onStripMouseDown,
   startStripDrag,
   formatVal,
-} = useDisplayRange(ionMatrix, colormap, ionCols, ionRows)
+} = useDisplayRange(currentIonMatrix, colormap, ionCols, ionRows)
+
+// ---- ROI ----
 
 const {
   roiOverlayRef,
@@ -82,12 +124,16 @@ const {
   roiReset,
   onDraftUpdated,
   onDraftCleared,
-} = useResultROI(ionMatrix, ionCols, ionRows)
+} = useResultROI(currentIonMatrix, ionCols, ionRows)
+
+// ---- Overlay ----
 
 const { overlayMode, overlayData, overlayLoading, overlayAlpha, toggleOverlay } = useOverlayData(
   ionRows,
   ionCols,
 )
+
+// ---- 统计信息 ----
 
 const spectrumStats = computed(() => ({
   intensityRange: getIntensityRange(),
@@ -103,6 +149,17 @@ const displayInfo = computed(() => ({
   storageMode: storageMode.value,
 }))
 
+// ---- 选中像素坐标（processed 模式） ----
+
+const selectedPixelCoord = computed(() => {
+  const spec = pixelSpectrum.value
+  if (!spec) return null
+  return { x: spec.x, y: spec.y }
+})
+
+// ---- 事件处理 ----
+
+/** 重置所有控件到默认值 */
 const resetControls = () => {
   mzTolerance.value = ZARR_STORE.defaultMzTolerance
   colormap.value = 'inferno'
@@ -126,6 +183,20 @@ const onDisplayMinChange = (value: number) => {
 const onDisplayMaxChange = (value: number) => {
   displayMax.value = value
 }
+
+// ---- processed 模式：TIC 图点击 → 加载像素谱 ----
+
+async function onSelectPixel(col: number, row: number) {
+  if (!isProcessed.value) return
+  const ctx = getSharedZarrContext()
+  if (!ctx.store) return
+
+  // 在像素坐标中查找最近的像素
+  const pixelIdx = await ctx.store.findPixelByPosition(col, row)
+  if (pixelIdx >= 0) {
+    await loadPixelSpectrum(pixelIdx)
+  }
+}
 </script>
 
 <template>
@@ -141,7 +212,7 @@ const onDisplayMaxChange = (value: number) => {
     <template #main>
       <IonImageSection
         :is-stale="isStale"
-        :ion-matrix="ionMatrix"
+        :ion-matrix="currentIonMatrix"
         :display-matrix="displayMatrix"
         :selected-mz="selectedMz"
         :mz-tolerance="mzTolerance"
@@ -159,6 +230,8 @@ const onDisplayMaxChange = (value: number) => {
         :calc-handle-top="calcHandleTop"
         :clamp-pct="clampPct"
         :format-val="formatVal"
+        :data-mode="dataMode"
+        :selected-pixel-coord="selectedPixelCoord"
         @update:mz-tolerance="mzTolerance = $event"
         @update:colormap="colormap = $event"
         @update:intensity-scale="intensityScale = $event"
@@ -170,6 +243,7 @@ const onDisplayMaxChange = (value: number) => {
         @start-strip-drag="startStripDrag"
         @draft-updated="onDraftUpdated"
         @draft-cleared="onDraftCleared"
+        @select-pixel="onSelectPixel"
       />
 
       <SpectrumSection
@@ -179,6 +253,7 @@ const onDisplayMaxChange = (value: number) => {
         :mz-tolerance="mzTolerance"
         :intensity-range="spectrumStats.intensityRange"
         :spectrum-mode="spectrumMode"
+        :data-mode="dataMode"
         @select-mz-index="onSpectrumClickByIndex"
       />
     </template>


### PR DESCRIPTION
* feat: adapt to new massflow.msi_zarr v1.0 format, add processed mode support, update metadata from zarr, add Explore button

- Rewrite ZarrOssStore for new zarr v1.0 structure (data/intensity + data/offsets + axes/coordinates)
- Support two data modes: continuous (ion image + mean spectrum) and processed (TIC + per-pixel spectrum)
- Fix 2D chunk row-stride bug in fetchArrayFull (chunkShape[0] → chunkShape[1])
- Read root/data/metadata attributes from zarr.json instead of .zattrs
- Get all metadata (analyzer, ion source, polarity, pixel size, spectrum mode, storage mode) from zarr metadata
- Remove backend API metadata lookup and preprocessing method spectral mode overrides
- Add preprocessing rules: no peak alignment for continuous storage, peak alignment requires peak picking for profile mode
- Add Explore button to dataset cards on MyDatasets and PublicDatasets pages
- Mode-aware UI titles: Ion Image/TIC Image, Average Spectrum/Spectrum

* new analysis添加publicdatasets

* 修复ResultDetailState 接口里没有 methods 字段，但代码里读了这个属性