### PR TITLE
Add download-data guide, fix spectrum chart alignment, require login …

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,6 +27,7 @@ const en = {
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Uploading Data', link: '/guide/upload-data' },
+          { text: 'Downloading Data', link: '/guide/download-data' },
           { text: 'Viewing Data', link: '/guide/view-data' },
         ],
       },
@@ -64,6 +65,7 @@ const zh = {
         items: [
           { text: '快速开始', link: '/zh/guide/getting-started' },
           { text: '上传数据', link: '/zh/guide/upload-data' },
+          { text: '下载数据', link: '/zh/guide/download-data' },
           { text: '查看数据', link: '/zh/guide/view-data' },
         ],
       },

--- a/docs/en/guide/download-data.md
+++ b/docs/en/guide/download-data.md
@@ -1,0 +1,54 @@
+# Downloading Data
+
+This page explains how to download raw MSI data (`.imzML` / `.ibd` file pairs) from the SpatialXomics platform.
+
+## Before You Download
+
+- **Login required**: You must be logged in to download. Clicking the download button while not authenticated will redirect you to the login page with a prompt.
+- **Original file pairs**: Each download delivers both the `.imzML` and `.ibd` files for the dataset.
+- **Rate limit**: A cooldown period (1 minute) is enforced between consecutive downloads to prevent excessive requests.
+- **Download quota**: Each account has a download limit managed by the administrator. Contact your admin if you exceed it.
+
+## Steps
+
+#### 1. Download from the dataset list
+
+Each dataset card on the **Public Datasets** or **My Datasets** page includes a download button. Click it to start downloading.
+
+![download-1](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-1.png)
+
+#### 2. Login redirect for unauthenticated users
+
+If you are not logged in, clicking download shows a warning toast and redirects you to the login page. After logging in, return to the list and try again.
+
+![download-2](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-2.png)
+
+#### 3. Download from the dataset detail page
+
+Click a dataset card to open its **Overview** page. A download button is also available there — login is still required.
+
+![download-3](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-3.png)
+
+#### 4. Download status feedback
+
+Once clicked, a toast notification appears at the top (Downloading… / Download started). Your browser will then download the `.imzML` and `.ibd` files in sequence.
+
+![download-4](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-4.png)
+
+![download-5](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-5.png)
+
+## Download Limits
+
+- **Cooldown**: A 60-second cooldown is enforced between downloads. During the cooldown you will see "Download is limited. Please wait Xs."
+
+![download-6](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-6.png)
+
+- **Quota**: Each account has a maximum download count. Contact your administrator if you need an increase.
+
+![download-7](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-7.jpg)
+
+## Tips
+
+- If nothing happens after clicking download, check whether your browser is blocking multiple-file downloads. Allow downloads for this site in your browser settings.
+- If a download fails, check your network connection first, then retry.
+- If downloads consistently fail, your account quota may be exhausted — contact your administrator.

--- a/docs/en/guide/view-data.md
+++ b/docs/en/guide/view-data.md
@@ -1,32 +1,307 @@
 # Viewing Data
 
-Once a dataset is uploaded and analyzed, the result page in SpatialXomics gives you several linked views for exploring your mass spectrometry imaging data.
+SpatialXomics offers two ways to turn mass spectrometry imaging data into interactive visualizations:
+
+## Two Visualization Methods
+
+### One-Click Visualization (Explore / Raw-Convert) — Recommended
+
+Launch directly from the dataset list with zero preprocessing configuration — the backend handles all conversion steps automatically.
+
+**Use cases**: Quick data browsing, first-time dataset exploration, no custom preprocessing needed.
+
+**Steps:**
+
+1. On the **Public Datasets** or **My Datasets** page, find the target dataset card.
+2. If the card button shows **Explore**, the dataset hasn't been converted yet. Click it to start one-click visualization.
+3. A confirmation dialog titled "Prepare Visualization" will appear — click **Generate** to confirm.
+4. After the "Task is in progress" toast, the page redirects to the Workspace where you can track the conversion progress. If no redirect occurs, the task already exists in another user's workspace — simply wait a moment and the button will change to Visualize.
+5. Once the task status shows `completed`, click **View** to open the result page.
+
+![view-1](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-1.png)
+
+![view-2](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-2.png)
+
+**Returning visits**: After conversion, the dataset card button changes to **Visualize**. Clicking it opens the result page directly — no repeated conversion needed.
+
+![view-3](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-3.png)
+
+### Preprocessing Analysis (Workspace Analysis)
+
+Create an analysis task manually in the Workspace, choosing your own algorithms and parameters for noise reduction, baseline correction, normalization, peak picking, and peak alignment.
+
+**Use cases**: Fine-grained control over the preprocessing pipeline, comparing algorithm performance, reproducing analysis workflows.
+
+**Steps:**
+
+1. Go to the **Workspace** and click **New Task**.
+2. Select the target dataset.
+3. Configure the preprocessing pipeline step by step: noise reduction, baseline correction, normalization, peak picking, and peak alignment — each step supports different algorithms with adjustable parameters.
+4. Review the summary panel and click **Start Analysis** to submit.
+5. Wait for the task to complete, then click **View** to open the result page.
+
+![view-4](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-4.png)
+
+> Regardless of the method, the final interactive visualization interface (ion image, spectrum, ROI, cluster overlays, etc.) is identical. The sections below cover how to use the result page.
+
+---
+
+## Entering the Result Page
+
+After generating a visualization through either method above, tasks with a `completed` status in the **Workspace** task list will show a **View** button. Click it to enter the result page.
+
+![view-5](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-5.png)
+
+> The result page is at `/workspace/results` and requires login. Tasks with a `processing` or `failed` status cannot be viewed yet.
+
+## Page Layout
+
+The result page uses a two-column layout:
+
+- **Left main area**: Ion image or TIC image at the top (with toolbar and zoom controls), spectrum at the bottom (with summary stats).
+- **Right panel (ColorBar)**: Display range adjustment, statistical histogram, dataset metadata, preprocessing methods, and UMAP / KMeans / ROI overlay controls.
+
+![view-6](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-6.png)
+
+---
+
+## Data Modes
+
+The result page supports two data viewing modes, determined by the dataset's storage mode:
+
+| Mode | Description | What you can do |
+|---|---|---|
+| **Continuous** | Renders the ion intensity distribution for a given m/z | Switch m/z, view average spectrum, click peaks to link |
+| **Processed** | Renders the TIC (Total Ion Current) image | View TIC image, click a pixel to see its spectrum |
+
+Interactions differ between the two modes, as explained in the sections below.
+
+---
 
 ## Ion Image
 
-- Renders the ion image for a selected m/z value, with scroll-wheel zoom and drag-to-pan.
-- Switch colormaps (e.g. inferno) and intensity scale (linear / log), and fine-tune the displayed range with min/max sliders.
+### Basic Operations
 
-## Average Spectrum
+- **Zoom**: Mouse scroll wheel to zoom, centered on the cursor position.
+- **Pan**: When zoomed beyond 1×, drag to pan the image.
+- **Zoom controls**: − / + buttons with current zoom level in the bottom-right corner. Click **Reset** to return to 1:1.
+- **Pixel hover**: Hovering over the image shows a tooltip — pixel coordinates (col, row) and intensity value.
 
-- Shows the dataset's mean mass spectrum as a bar chart.
-- Click a peak to switch the ion image to that m/z; conversely, clicking a point on the ion image updates the highlighted position in the spectrum.
+![view-7](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-7.png)
+
+### Toolbar
+
+The toolbar above the image provides the following controls:
+
+| Control | Description | Mode |
+|---|---|---|
+| Title | Shows the current mode name (Ion Image / TIC Image) | Both |
+| m/z value | Displays the currently selected m/z | Continuous |
+| Tolerance | Adjusts the m/z matching tolerance (min 0.001) | Continuous |
+| Colormap | Switch between Viridis / Inferno / Plasma / Gray | Both |
+| Intensity Scale | Switch between Linear or Log scale | Both |
+| Reset | Reset all image parameters (tolerance, colormap, scale, gamma, display range) | Both |
+
+> **About Tolerance**: Due to instrument precision, the same ion may be measured at slightly different m/z values across runs. Tolerance defines the acceptable deviation for matching — for example, with a tolerance of 0.01 and a selected m/z of 889.58, signals in the range 889.57 ~ 889.59 are considered the same ion. Smaller tolerance means stricter matching; larger tolerance widens the match window. Adjust based on your data's precision.
+
+![view-8](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-8.png)
+
+### Display Range Adjustment
+
+Each pixel in the ion image is colored according to its ion intensity: **low intensity → dark end, high intensity → bright end**, with intermediate values mapped through the current colormap.
+
+The vertical gradient strip to the right of the image visualizes this mapping — showing the full intensity gradient from top to bottom in the current colormap — and supports manual range adjustment:
+
+- Drag the Min / Max handles to adjust the range bounds.
+- Click between the handles on the strip to jump to that position.
+- Click the ↺ button to restore the automatic range (P1 ~ P95).
+
+### Gamma Adjustment
+
+The **Visualization** section in the right panel provides a Gamma slider, ranging from 0.5 to 1.5. Increasing Gamma brightens low-intensity regions; decreasing Gamma enhances contrast in highlight regions.
+
+**Gamma = 1.0 (default):**
+
+![view-9](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-9.png)
+
+**Gamma = 0.5:**
+
+![view-10](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-10.png)
+
+### Pixel Click in Processed Mode
+
+In Processed / TIC mode, clicking a pixel in the image loads that pixel's spectrum (see the Spectrum section below). The system distinguishes between dragging and clicking (movement over 3px is treated as a drag and does not trigger selection).
+
+![view-11](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-11.png)
+
+---
+
+## Spectrum
+
+The spectrum is rendered with ECharts, located below the ion image.
+
+### Spectrum Modes
+
+The spectrum has two display modes based on data characteristics:
+
+| Mode | Display | Data Mode |
+|---|---|---|
+| **Centroid** | Bar chart — each bar represents a detected peak | Continuous / Processed |
+| **Profile** | Continuous line chart — shows the full spectrum profile | Continuous / Processed |
+
+**Centroid:**
+
+![view-12](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-12.png)
+
+**Profile:**
+
+![view-13](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-13.png)
+
+### Continuous Mode Interactions
+
+- **Average spectrum**: Shows the mean spectrum across all pixels in the dataset.
+- **Click to select peaks**: Click anywhere in the spectrum to switch the ion image to the corresponding m/z.
+- **Red selection line**: A red vertical line marks the currently selected m/z, staying in sync during zooming.
+- **Bidirectional linkage**: Click a point on the ion image → spectrum highlight updates; click a peak in the spectrum → ion image switches to that m/z.
+
+For example, clicking the peak at m/z 889.5810 in the spectrum will automatically switch the ion image to show the intensity distribution at that m/z.
+
+![view-14](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-14.png)
+
+### Processed Mode Interactions
+
+- **Pixel spectrum**: After clicking a pixel in the TIC image, the spectrum switches to that pixel's mass spectrum, with the title showing "Spectrum — Pixel (66, 66)".
+
+![view-15](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-15.png)
+
+### Zooming & Browsing
+
+- **Built-in zoom**: ECharts supports drag-to-select region zooming (dataZoom).
+- **Bottom slider**: Drag the slider handles to adjust the X-axis (m/z) display range.
+
+### Summary Statistics
+
+A statistical summary of the current data is displayed below the spectrum:
+
+| Stat | Continuous Mode | Processed Mode |
+|---|---|---|
+| Peak count | Number of detected peaks | Number of peaks at this pixel |
+| Intensity range | Min / Max intensity | Min / Max intensity |
+| Selected m/z | Current m/z ± tolerance | — |
+| Pixel coordinates | — | (x, y) of the selected pixel |
+
+### Retry
+
+If spectrum loading fails, an error message and **Retry** button are displayed. Click to reload.
+
+---
+
+## Right Panel (ColorBar)
+
+### Display Range
+
+- Shows the current Min / Max intensity values and their corresponding percentiles.
+- Percentile labels are derived via binary search on sorted values.
+
+### Statistical Histogram
+
+- A 10-bin intensity distribution histogram (Canvas-rendered).
+- Red marker lines indicate the position of the current displayMin / displayMax within the distribution.
+- Text stats: **Dimensions** (total pixel count), **Non-zero** (non-zero pixel ratio), **TIC** (total ion current).
+
+### Metadata (Info)
+
+Displays the dataset's acquisition and analysis parameters:
+
+| Field | Description |
+|---|---|
+| Polarity | positive / negative |
+| Analyzer | Analyzer type (e.g. Q-TOF) |
+| Ionisation Source | Ion source (e.g. ESI, MALDI) |
+| Pixel Size | Pixel dimensions (μm) |
+| Spectrum Mode | centroid / profile |
+| Storage Mode | continuous / processed |
+
+### Preprocessing Methods
+
+Lists the preprocessing methods applied to this dataset during analysis.
+
+![view-16](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-16.png)
+
+---
 
 ## ROI Analysis
 
-- Draw polygon regions of interest (ROIs) directly on the ion image, and adjust or confirm the selection.
-- Use ROIs to focus further statistics or comparisons on a specific tissue region.
+Draw regions of interest on the ion image to focus statistical analysis or comparison on specific tissue areas.
 
-## UMAP / K-Means Cluster Overlay
+### Drawing Tools
 
-- Loads the dataset's UMAP embedding and K-Means cluster labels (5 clusters by default) and renders them as a color overlay on the ion image, with an adjustable overlay opacity.
-- Useful for quickly spotting groups of pixels with similar metabolic/chemical profiles within the same tissue section.
+The **Region of interest** section in the right panel provides two drawing modes:
 
-## Dataset Metadata
+| Tool | How to use | Visual style |
+|---|---|---|
+| **Rectangle** | Click and drag on the image to draw a rectangle. Corner handles allow resizing; click inside to reposition. | Red semi-transparent fill + red stroke |
+| **Lasso** | Click point by point to draw a polygon. The path auto-closes (minimum 5 points). | Blue stroke |
 
-The result page also displays dataset metadata — name, analyzer type, ionization source, pixel size, polarity, spectrum mode, storage mode, and processing methods — so you can double-check the analysis parameters.
+### Confirming & Managing
+
+- After drawing, click **Confirm** to finalize the ROI. The system automatically calculates statistics (pixel count, mean, std dev, min, max, sum).
+- Click **Cancel** to discard the current draft.
+- Confirmed ROIs appear in the list, each with a color label. Delete individually or use **Clear All** to remove all.
+- Up to 6 colors are assigned, cycling as needed.
+
+**Drawing an ROI:**
+
+![view-17](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-17.png)
+
+**Confirming an ROI:**
+
+![view-18](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-18.png)
+
+### Viewing ROI Mode
+
+After confirming an ROI, the image automatically switches to **Viewing ROI** mode — only pixels within the ROI area are shown, the rest are hidden for focused analysis.
+
+**Multiple selections**: You can draw and confirm multiple ROIs in sequence. The system displays the union of all confirmed ROIs — pixels belonging to any ROI are retained, all others remain hidden. Click **Reset** to restore the full image.
+
+> To draw a new ROI in a different area, click **Reset** first to restore the full image. Otherwise Viewing ROI mode will only show pixels within existing ROI boundaries.
+
+![view-19](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-19.png)
+
+---
+
+## UMAP / KMeans Cluster Overlay
+
+Overlay dimensionality reduction and clustering results as color layers on the ion image to quickly identify groups of pixels with similar metabolic/chemical profiles within the same tissue section.
+
+### UMAP Overlay
+
+- Maps the 3D UMAP embedding coordinates to RGB color channels, giving each pixel a unique color with smooth gradients.
+- Regions with similar metabolic features appear in similar colors.
+
+### KMeans Overlay
+
+- Uses a 20-color palette to assign colors to cluster labels.
+- Default cluster count K=5, displayed as discrete color blocks.
+
+### Control Panel
+
+The right panel provides the following controls:
+
+| Control | Description |
+|---|---|
+| UMAP button | Toggle UMAP overlay on / off (click again to close) |
+| KMeans button | Toggle KMeans overlay on / off (click again to close) |
+| Opacity slider | Adjust overlay transparency (0 ~ 100%) for comparison with the underlying ion image |
+
+- ROI and cluster overlays can be enabled simultaneously. Adjust layer order and opacity for the best contrast.
+
+---
 
 ## Tips
 
-- Selection between the ion image and the spectrum is bidirectional, making it easy to home in on an m/z of interest.
-- ROI and cluster overlays can be enabled together; adjust layer order and opacity to get the clearest contrast.
+- Selection between the ion image and spectrum is bidirectional — making it easy to home in on an m/z of interest.
+- ROI and cluster overlays can be enabled together; adjust layer order and opacity for the clearest contrast.
+- The zoom center follows your cursor — position the mouse precisely to zoom into the area of interest.
+- The dataZoom slider at the bottom of the spectrum is ideal for quickly navigating m/z ranges, especially for wide mass range data.
+- Result page data comes from Zarr-format preprocessed files. Initial loading may take a few seconds — please be patient.

--- a/docs/zh/guide/download-data.md
+++ b/docs/zh/guide/download-data.md
@@ -1,0 +1,54 @@
+# 下载数据
+
+本页介绍如何从 SpatialXomics 平台下载已上传的 MSI 原始数据（`.imzML` / `.ibd` 文件对）。
+
+## 下载须知
+
+- **需要登录**：下载操作需要登录账号；未登录状态下点击下载按钮，会自动跳转至登录页并提示需要登录。
+- **下载的是原始文件对**：每次下载会同时获取该数据集对应的 `.imzML` 与 `.ibd` 两个文件。
+- **频率限制**：两次下载操作之间需等待冷却时间(一分钟)，避免频繁请求。
+- **次数配额**：每个账号存在下载次数上限，由管理员统一管理，超出后请联系管理员。
+
+## 操作步骤
+
+#### 1.从数据集列表页下载
+
+无论是「公开数据集」（Public Datasets）还是「我的数据集」（My Datasets）列表页，每个数据集卡片上都提供下载按钮，点击即可发起下载。
+
+![download-1](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-1.png)
+
+#### 2.未登录时会跳转登录页
+
+若未登录时点击下载，会弹出提示并自动跳转到登录页；登录成功后可返回列表页继续操作。
+
+![download-2](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-2.png)
+
+#### 3.从数据集详情页下载
+
+点击数据集卡片进入详情（Overview）页，页面内同样提供下载按钮，点击即可下载当前数据集，同样需要登录。
+
+![download-3](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-3.png)
+
+#### 4.下载进行中的状态提示
+
+点击下载后，页面顶部会显示下载状态提示（下载中 / 下载已开始）；浏览器会依次下载 `.imzML` 与 `.ibd` 两个文件。
+
+![download-4](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-4.png)
+
+![download-5](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-5.png)
+
+## 下载限制
+
+- **冷却时间**：两次下载之间需等待 60 秒冷却时间；冷却期内点击会提示「Download is limited. Please wait Xs.」。
+
+![download-6](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-6.png)
+
+- **次数配额**：每个账号有下载次数上限，超出后请联系管理员调整。
+
+![download-7](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/download-7.jpg)
+
+## 小贴士
+
+- 若下载没有反应，请检查浏览器是否拦截了多文件下载弹窗，需在浏览器设置中允许该站点的下载权限。
+- 下载失败时优先检查网络连接，稍后重新点击下载按钮重试。
+- 若长期无法下载，可能是账号配额已用尽，请联系管理员核实。

--- a/docs/zh/guide/view-data.md
+++ b/docs/zh/guide/view-data.md
@@ -1,32 +1,308 @@
 # 查看数据
 
-数据上传并完成分析后，SpatialXomics 在结果页提供多种联动视图来交互式地探索质谱成像数据。
+SpatialXomics 提供两种方式将质谱成像数据转为可交互的可视化结果：
+
+## 两种可视化方式
+
+### 一键可视化（Explore / Raw-Convert）
+
+无需配置任何预处理参数，从数据集列表页直接发起，后端自动完成所有转换步骤。
+
+**适用场景**：快速浏览数据、初次查看数据集内容、无需自定义预处理流程。
+
+**操作步骤：**
+
+1. 在 **公开数据集** 或 **我的数据集** 列表中，找到目标数据集卡片。
+2. 若卡片按钮显示 **Explore**，说明该数据集尚未转换过，点击即可发起一键可视化。
+3. 系统弹出确认框，标题为「Prepare Visualization」，点击 **Generate** 确认。
+4. 提示「Task is in progress」后，页面自动跳转到工作区（Workspace），可在任务列表中跟踪转换进度。若未发生跳转，说明该任务已存在于他人工作区，只需稍作等待，按钮变为Visualize即可查看。
+5. 任务状态变为 `completed` 后，点击 **View** 进入结果页查看。
+
+![view-1](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-1.png)
+
+![view-2](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-2.png)
+
+**再次查看**：转换完成后，数据集卡片按钮会变为 **Visualize**，点击直接进入结果页，无需重复转换。
+
+![view-3](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-3.png)
+
+### 预处理分析（Workspace Analysis）
+
+在 Workspace 中手动创建分析任务，自行选择去噪、基线校正、归一化、峰检测、峰对齐等预处理算法和参数。
+
+**适用场景**：需要精细控制预处理流程、对比不同算法效果、复现分析过程。
+
+**操作步骤：**
+
+1. 进入 **工作区（Workspace）**，点击 **New Task**。
+2. 选择目标数据集。
+3. 逐步配置预处理流水线：噪声去除、基线校正、归一化、峰检测、峰对齐——每步可选用不同算法并调节参数。
+4. 在摘要面板确认配置后，点击 **Start Analysis** 提交任务。
+5. 等待任务完成后，点击 **View** 进入结果页。
+
+![view-4](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-4.png)
+
+> 无论哪种方式，最终的交互式可视化界面（离子图像、质谱图、ROI、聚类叠加等）是相同的。下文各节介绍结果页的统一操作方式。
+
+---
+
+## 如何进入结果页
+
+通过以上任一方式生成可视化任务后，在 **工作区（Workspace）** 的任务列表中，状态为 `completed` 的任务会显示 **View** 按钮，点击即可进入结果页。
+
+![view-5](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-5.png)
+
+> 结果页路径为 `/workspace/results`，需要登录才可访问。若任务状态为 `processing` 或 `failed`，则暂时无法查看结果。
+
+## 页面布局
+
+结果页采用两栏布局：
+
+- **左侧主区域**：上方为离子图像或TIC图像（含工具栏和 Zoom 控件），下方为质谱图（含底部统计信息）。
+- **右侧面板（ColorBar）**：包含显示范围调节、统计直方图、数据集元信息、预处理方法，以及 UMAP / KMeans / ROI 叠加控制。
+
+![view-6](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-6.png)
+
+---
+
+## 数据模式
+
+结果页支持两种数据查看模式，由数据集本身的存储模式决定：
+
+| 模式 | 说明 | 可以做什么 |
+|---|---|---|
+| **Continuous** | 以某个 m/z 的离子强度分布渲染图像 | 切换 m/z、查看平均质谱、点击峰联动 |
+| **Processed** | 以 TIC（Total Ion Current）渲染图像 | 查看 TIC 图、点击像素查看该像素的质谱 |
+
+两种模式下的交互有所差异，下文各节会分别说明。
+
+---
 
 ## 离子图像
 
-- 按选定的 m/z 值渲染离子图像，支持滚轮缩放、拖拽平移。
-- 可切换配色方案（如 inferno 等）与强度刻度（线性 / 对数），并通过最小 / 最大值滑块调整显示范围。
+### 基本操作
 
-## 平均质谱图
+- **缩放**：鼠标滚轮缩放，以鼠标位置为中心。
+- **平移**：缩放超过 1× 后，可拖拽平移图像。
+- **Zoom 控件**：图像右下角提供 − / + 按钮和当前倍率显示，点击 Reset 可恢复 1:1。
+- **像素悬停**：鼠标悬停在图像上时，显示浮窗信息——像素坐标 (col, row) 与强度值。
 
-- 以条形图展示整张数据集的平均质谱。
-- 点击谱图中的某个峰，会联动切换离子图像到对应 m/z；反过来在离子图像上选点，也会更新谱图高亮位置。
+![view-7](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-7.png)
+
+### 工具栏
+
+图像顶部工具栏提供以下控件：
+
+| 控件 | 说明 | 适用模式 |
+|---|---|---|
+| 标题 | 显示当前模式名称（Ion Image / TIC Image） | 通用 |
+| m/z 值 | 显示当前选的 m/z 值 | Continuous |
+| 容差（Tolerance） | 调节 m/z 匹配容差（最小 0.001） | Continuous |
+| 配色方案（Colormap） | 切换 Viridis / Inferno / Plasma / Gray 四种配色 | 通用 |
+| 强度刻度（Scale） | 切换 Linear（线性）或 Log（对数） | 通用 |
+| Reset | 一键重置所有图像参数（容差、配色、刻度、Gamma、显示范围） | 通用 |
+
+> **关于容差**：质谱仪在检测同一离子时，受仪器精度影响，实际测得的 m/z 值可能存在细微偏差。容差定义了匹配时允许的误差范围——例如，当容差设为 0.01、选中 m/z 为 889.58 时，系统会将 m/z 在 889.57 ~ 889.59 范围内的信号视为同一离子。容差越小匹配越严格，越大则匹配范围越宽，可根据数据精度灵活调节。
+
+![view-8](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-8.png)
+
+### 显示范围调节
+
+离子图像中的每个像素颜色由该位置的离子强度值决定：**低强度→深色端，高强度→亮色端**，中间值按当前配色方案（Colormap）进行渐变映射。
+
+图像右侧的垂直强度条（Gradient Strip）直观展示了这一映射关系，自上而下为当前配色对应的完整强度梯度，并支持手动调节显示范围：
+
+- 拖动 Min / Max 手柄调整范围上下限。
+- 点击手柄之间的强度条可快速移动到对应位置。
+- 点击 ↺ 按钮恢复自动范围（P1 ~ P95）。
+
+### Gamma 调节
+
+右侧面板的 **Visualization** 区域提供 Gamma 滑块，范围 0.5 ~ 1.5。增大 Gamma 使低强度区域更亮，减小 Gamma 则增强高亮区域对比度。
+
+**Gamma = 1.0（默认）：**
+
+![view-9](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-9.png)
+
+**Gamma = 0.5：**
+
+![view-10](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-10.png)
+
+### Processed 模式下的像素点击
+
+在 Processed / TIC 模式下，点击图像中的像素会加载该像素的质谱图（见下文质谱图部分）。系统会区分拖拽与点击（移动超过 3px 视为拖拽，不触发选择）。
+
+![view-11](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-11.png)
+
+---
+
+## 质谱图
+
+质谱图基于 ECharts 渲染，位于离子图像下方。
+
+### 谱图模式
+
+根据数据特性，质谱图有两种呈现方式：
+
+| 模式 | 显示 | 对应数据模式 |
+|---|---|---|
+| **Centroid（质心谱）** | 柱状图，每根柱子代表一个检测到的峰 | Continuous / Processed|
+| **Profile（轮廓谱）** | 连续折线图，展示完整谱图轮廓 | Continuous / Processed |
+
+**Centroid（质心谱）：**
+
+![view-12](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-12.png)
+
+**Profile（轮廓谱）：**
+
+![view-13](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-13.png)
+
+### Continuous 模式下的交互
+
+- **平均质谱**：显示整个数据集所有像素点的平均质谱。
+- **点击选峰**：点击谱图中任意位置，离子图像会自动切换到对应的 m/z 值。
+- **红色选择线**：当前选中 m/z 处显示红色竖线，随缩放保持同步。
+- **联动高亮**：离子图像上选点 → 谱图高亮位置更新；谱图点击峰 → 离子图像切换 m/z。双向联动。
+
+例如，在谱图中点击 m/z 889.5810 处的峰，离子图像将自动切换到该 m/z 值的离子强度分布图。
+
+![view-14](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-14.png)
+
+### Processed 模式下的交互
+
+- **像素质谱**：点击 TIC 图像中的像素后，谱图切换为该像素的质谱，标题显示 "Spectrum — Pixel (66, 66)"。
+
+![view-15](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-15.png)
+
+### 缩放与浏览
+
+- **内置缩放**：ECharts 支持鼠标框选区域放大（dataZoom）。
+- **底部滑块**：拖拽滑块两端调整 X 轴（m/z）显示范围。
+
+### 底部统计信息
+
+谱图下方显示当前数据的统计摘要：
+
+| 统计项 | Continuous 模式 | Processed 模式 |
+|---|---|---|
+| Peaks 数 | 检测到的峰数量 | 该像素的峰数量 |
+| Intensity 范围 | 最小 / 最大强度值 | 最小 / 最大强度值 |
+| Selected m/z | 当前选中的 m/z 值 + 容差 | — |
+| Pixel 坐标 | — | 当前选中像素的 (x, y) |
+
+### 重试
+
+谱图加载失败时，显示错误提示与 **Retry** 按钮，点击可重新加载。
+
+---
+
+## 右侧面板（ColorBar）
+
+### 显示范围（Display Range）
+
+- 显示当前 Min / Max 强度值及其对应百分位。
+- 基于排序后的数值进行二分查找得出百分位标签。
+
+### 统计直方图（Statistic）
+
+- 10 个 bin 的强度分布直方图（Canvas 绘制）。
+- 红色标记线指示当前 displayMin / displayMax 在分布中的位置。
+- 文本统计：**Dimensions**（总像素数）、**Non-zero**（非零像素比例）、**TIC**（总离子流值）。
+
+### 元信息（Info）
+
+显示数据集的采集与分析参数：
+
+| 字段 | 说明 |
+|---|---|
+| Polarity | 极性（positive / negative） |
+| Analyzer | 分析仪类型（如 Q-TOF） |
+| Ionisation Source | 离子源（如 ESI、MALDI） |
+| Pixel Size | 像素大小（μm） |
+| Spectrum Mode | 谱图模式（centroid / profile） |
+| Storage Mode | 存储模式（continuous / processed） |
+
+### 预处理方法（Preprocessing）
+
+展示该数据集在分析过程中应用过的预处理方法列表。
+
+![view-16](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-16.png)
+
+---
 
 ## ROI 区域分析
 
-- 在离子图像上绘制多边形选区（ROI），可调整、确认选区范围。
-- 用于聚焦特定组织区域做进一步的统计或对比分析。
+在离子图像上绘制感兴趣区域（Region of Interest），聚焦特定组织区域进行统计或对比分析。
 
-## UMAP / K-Means 聚类叠加
+### 绘制工具
 
-- 加载该数据集的 UMAP 降维结果与 K-Means 聚类标签（默认 5 类），以彩色图层叠加在离子图像上，并可调整叠加图层的透明度。
-- 用于快速判断同一组织切片内不同区域的代谢/化学相似性分组。
+右侧面板的 **Region of interest** 区域提供两种绘制模式：
 
-## 数据集元信息
+| 工具 | 操作方式 | 显示样式 |
+|---|---|---|
+| **Rectangle（矩形）** | 在图像上按住拖拽绘制矩形，四角手柄可调整大小，点击内部可移动 | 红色半透明填充 + 红色描边 |
+| **Lasso（自由形状）** | 在图像上逐点点击绘制多边形，系统自动闭合路径（至少 5 个点） | 蓝色描边 |
 
-结果页同时展示数据集名称、分析仪类型、离子源、像素大小、极性、谱图模式、存储模式与预处理方法等元数据，方便核对分析参数。
+### 确认与管理
+
+- 绘制完成后点击 **Confirm** 确认 ROI，系统自动计算该区域的统计信息（像素数、均值、标准差、最小值、最大值、总和）。
+- 点击 **Cancel** 清除当前草稿。
+- 确认后的 ROI 会显示在列表中，每个 ROI 有其颜色标签，可单独删除或一键 **Clear All**。
+- 最多分配 6 种颜色，循环使用。
+
+**绘制 ROI：**
+
+![view-17](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-17.png)
+
+**确认 ROI：**
+
+![view-18](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-18.png)
+
+### Viewing ROI 模式
+
+确认 ROI 后，图像自动切换为 **Viewing ROI** 模式——仅显示 ROI 区域内的像素，其余像素隐藏，便于聚焦分析。
+
+**多次选择**：可依次绘制并确认多个 ROI，系统会对所有已确认的 ROI 取并集显示——即属于任一 ROI 的像素均会保留，其余区域继续隐藏。点击 **Reset** 可恢复到完整图像。
+
+> 如需在新的区域继续绘制 ROI，请先点击 **Reset** 恢复完整图像，否则 Viewing ROI 模式下仅显示已有 ROI 范围内的像素。
+
+![view-19](https://official-oss.oss-cn-hongkong.aliyuncs.com/docs/view-19.png)
+
+---
+
+## UMAP / KMeans 聚类叠加
+
+将降维聚类结果以彩色图层叠加在离子图像上，快速判断同一组织切片内不同区域的代谢/化学相似性分组。
+
+### UMAP 叠加
+
+- 将 UMAP 降维的 3D 坐标映射为 RGB 颜色通道，每个像素获得唯一颜色，形成连续渐变。
+- 相似代谢特征的区域呈现相近颜色。
+
+### KMeans 叠加
+
+- 使用 20 色调色板为每个聚类标签分配颜色。
+- 默认聚类数 K=5，以离散色块区分不同分组。
+
+### 控制面板
+
+右侧面板提供以下控件：
+
+| 控件 | 说明 |
+|---|---|
+| UMAP 按钮 | 开启 / 关闭 UMAP 叠加层（再次点击关闭） |
+| KMeans 按钮 | 开启 / 关闭 KMeans 叠加层（再次点击关闭） |
+| 透明度滑块 | 调节叠加层的透明度（0 ~ 100%），方便与底层离子图像对照 |
+
+- ROI 与聚类叠加可以同时开启，叠加顺序与透明度可自行调整以获得最佳对比效果。
+
+
+---
 
 ## 小贴士
 
 - 离子图像与谱图的选择是双向联动的，便于快速定位感兴趣的 m/z。
 - ROI 与聚类叠加可以同时开启，叠加顺序与透明度可以自行调整以获得最佳对比效果。
+- 滚轮缩放时鼠标所在位置即为缩放中心，可以精准放大关注区域。
+- 谱图底部的 dataZoom 滑块适合快速定位 m/z 区间，尤其适用于宽质量范围的质谱数据。
+- 结果页数据来源于 Zarr 格式的预处理文件，首次加载可能需要几秒钟，期间请耐心等待。

--- a/src/features/datasets/composables/useDatasetDetail.ts
+++ b/src/features/datasets/composables/useDatasetDetail.ts
@@ -8,9 +8,11 @@ import { useDownloadProgress } from '@/features/datasets/composables/useDownload
 import { getDatasetPlaceholderSvg } from '@/features/datasets/utils/datasetPlaceholder'
 import { formatBytes } from '@/shared/utils/format'
 import { useToast } from '@/shared/composables/useToast'
+import { useAuthStore } from '@/features/auth/stores/authStore'
 
 export function useDatasetDetail() {
   const router = useRouter()
+  const auth = useAuthStore()
   const { handleDownloadRaw, isPacking } = useDownloadProgress()
   const { showToast } = useToast()
 
@@ -65,16 +67,27 @@ export function useDatasetDetail() {
     }
   }
 
+  /** 下载需要登录：未登录则提示并跳转登录页，与公开数据集列表页行为一致 */
+  const requireAuth = (): boolean => {
+    if (!auth.token) {
+      showToast('Please log in to continue.', 'warning')
+      const redirect = source.value === 'public' ? '/datasets' : '/mydatasets'
+      router.push({ path: '/login', query: { redirect } })
+      return false
+    }
+    return true
+  }
+
   const downloadCurrent = async () => {
     const targetId = dataset.value?.id ? String(dataset.value.id) : ''
     if (!targetId) return
+    if (!requireAuth()) return
     await handleDownloadRaw(targetId, {
       getFallbackFilename: () => {
         const filename = dataset.value?.filename || dataset.value?.name || undefined
         if (!filename) return undefined
         return filename.toLowerCase().endsWith('.zip') ? filename : `${filename}.zip`
       },
-      isPublic: isPublic.value,  // 公开页面不需要登录
     })
   }
 

--- a/src/features/workspace/results/components/visuals/AverageSpectrum.vue
+++ b/src/features/workspace/results/components/visuals/AverageSpectrum.vue
@@ -176,11 +176,62 @@ function scheduleSelectorUpdate() {
 }
 
 /**
+ * 为 dataZoom 缩略图构建"保峰 + 位置对齐"的抽稀数据。
+ *
+ * 两个问题都源自 ECharts 缩略图的实现（SliderZoomView.js 的 _renderDataShadow）：
+ * 1. 默认按固定步长等间隔抽稀原始 series（每隔 N 个点取 1 个），窄峰容易一个点
+ *    都取不到而在缩略图里"消失"——所以按桶取每个桶里的峰值点代替原始点。
+ * 2. 非 time 类型坐标轴下，缩略图每个点的横坐标是按"数组下标"均匀排开的
+ *    （宽度 / 点数），完全不看该点真实的 m/z 值；主图则是按真实 m/z 值经坐标轴
+ *    换算位置。当 chartData 里因过滤零值、centroid 峰间距本就不均匀等原因产生
+ *    "空白区间"（该区间的点在数组里整个不存在，而不是值为 0）时，下标就不再和
+ *    m/z 值成比例，缩略图形状会和主图错位。所以这里按真实 m/z 值等分桶（而不是
+ *    按下标等分），每个桶固定只产出 1 个点（桶内最大值，空桶补一个强度为 0 的
+ *    占位点），让输出数组里每个点的"下标顺序"精确对应等宽的真实 m/z 区间，
+ *    ECharts 按下标均匀布点的假设才成立（残余误差 ≤ 一个桶的宽度）。
+ *
+ * 最终作为一个透明的专属 series 插到 series 数组最前面，让 ECharts 的
+ * _prepareDataShadowInfo 选中它作为缩略图的数据来源（取匹配到的第一个 series）。
+ */
+function buildShadowData(data: ChartPoint[], targetWidth: number): ChartPoint[] {
+  const bucketCount = Math.max(1, Math.floor(targetWidth))
+  // 注意：即便原始点数少于 bucketCount 也不能跳过分桶直接返回原始数据——
+  // centroid 峰间距本就不均匀，跳过分桶会让 ECharts 缩略图按"下标均匀"摆点
+  // （而不是按真实 m/z），峰位置又会和主图对不上，桶数据这一步就白做了。
+  const mzMin = data[0]![0]
+  const mzMax = data[data.length - 1]![0]
+  const span = mzMax - mzMin
+  if (!(span > 0)) return data
+
+  const result: ChartPoint[] = []
+  let i = 0
+  for (let b = 0; b < bucketCount; b++) {
+    const bucketEnd = mzMin + ((b + 1) / bucketCount) * span
+    const isLastBucket = b === bucketCount - 1
+    let maxIdx = -1
+    while (i < data.length && (isLastBucket ? data[i]![0] <= bucketEnd : data[i]![0] < bucketEnd)) {
+      if (maxIdx === -1 || data[i]![1] > data[maxIdx]![1]) maxIdx = i
+      i++
+    }
+    if (maxIdx === -1) {
+      // 该 m/z 区间内没有数据点（例如强度为零被过滤掉的空白区），补一个基线点占位，
+      // 保证后续桶的"下标顺序"依然正比于真实 m/z 位置
+      const bucketStart = mzMin + (b / bucketCount) * span
+      result.push([bucketStart, 0])
+    } else {
+      result.push(data[maxIdx]!)
+    }
+  }
+  return result
+}
+
+/**
  * 构建完整 ECharts options。提取为独立函数，每次 render 都用
  * notMerge: true 传入，确保 dataZoom 缩略图与主图完全同步。
  */
-function buildOptions(): Record<string, unknown> {
+function buildOptions(targetWidth: number): Record<string, unknown> {
   const isProfile = props.spectrumMode === 'profile'
+  const shadowData = buildShadowData(props.chartData, targetWidth)
   return {
     tooltip: {
       trigger: 'axis',
@@ -199,6 +250,13 @@ function buildOptions(): Record<string, unknown> {
       type: 'value',
       name: 'm/z',
       scale: true,
+      // 显式钉死 min/max 为数据真实范围：scale:true 默认会取"nice"整数刻度，
+      // 往往比数据实际范围更宽，主图两侧就会留出空白；而 dataZoom 缩略图的阴影
+      // 永远是按（抽稀后）数据自身的最小/最大值撑满整个滑块宽度渲染的，不认
+      // 这个 nice 范围，于是两者边缘对不齐。钉死后主图也是从数据首尾点撑满，
+      // 和缩略图口径一致。
+      min: props.chartData[0]?.[0],
+      max: props.chartData[props.chartData.length - 1]?.[0],
       nameLocation: 'center',
       nameGap: 28,
       axisLabel: {},
@@ -228,6 +286,20 @@ function buildOptions(): Record<string, unknown> {
       },
     ],
     series: [
+      // 缩略图专用透明 series：放在数组最前面，供 dataZoom 滑块的 _prepareDataShadowInfo
+      // 选中作为缩略图数据源，数据已用 buildShadowData 做过峰值保留抽稀。
+      // tooltip.show: false 避免它混入 axis 触发的 tooltip。
+      {
+        id: 'spectrum-shadow-series',
+        type: 'line',
+        data: shadowData,
+        showSymbol: false,
+        silent: true,
+        tooltip: { show: false },
+        lineStyle: { opacity: 0 },
+        areaStyle: { opacity: 0 },
+        z: -100,
+      },
       isProfile
         ? {
             id: 'spectrum-series',
@@ -245,6 +317,10 @@ function buildOptions(): Record<string, unknown> {
             barGap: '-100%',
             itemStyle: { color: '#374151' },
             large: true,
+            // xAxis.min/max 钉死在首尾数据点上，柱子中心正好卡在网格边缘，
+            // 默认裁剪会把最左/最右柱子露出网格外的那一半切掉；关掉裁剪即可
+            // 完整显示，网格外侧还有 grid.left/right 的边距可以容纳这半根柱子。
+            clip: false,
           },
     ],
     animation: false,
@@ -278,7 +354,7 @@ function renderChart() {
   // 彻底销毁重建，保证 dataZoom 缩略图和主图完全一致
   chartInstance?.dispose()
   chartInstance = echarts.init(container)
-  chartInstance.setOption(buildOptions(), { notMerge: true })
+  chartInstance.setOption(buildOptions(container.clientWidth || 800), { notMerge: true })
 
   // 注册事件（仅 continuous 模式）
 

--- a/src/features/workspace/results/composables/useZarrIonImage.ts
+++ b/src/features/workspace/results/composables/useZarrIonImage.ts
@@ -120,10 +120,16 @@ export async function loadMeanSpectrum(): Promise<void> {
     }
 
     nMz.value = axis.length
+    // profile 模式下相邻点由折线连接，过滤掉零值会让 ECharts 在两个"幸存点"之间
+    // 画直线穿过整段空白区，凭空连出并不存在的信号，所以 profile 模式必须保留零值；
+    // centroid 模式每个峰是独立的 bar，过滤零值只是省去数万个空 bar，不影响视觉
+    const attrs = metadataAttrsRef.value
+    const isProfileMode = !!attrs?.profile_spectrum && !attrs?.centroid_spectrum
     const data: [number, number][] = []
     for (let i = 0; i < axis.length; i++) {
       const v = meanData[i]!
-      if (v !== 0 && Number.isFinite(v)) {
+      if (!Number.isFinite(v)) continue
+      if (isProfileMode || v !== 0) {
         data.push([axis[i]!, v])
       }
     }

--- a/src/services/zarrOssStore.ts
+++ b/src/services/zarrOssStore.ts
@@ -5,7 +5,7 @@
  *   - ion-major continuous → ion image + mean spectrum (existing feature)
  *   - pixel-major processed → TIC image + per-pixel spectrum (new feature)
  *
- * Layout (see public/zarr_schema.md):
+ * Layout:
  *   <root>/.zattrs              — root attributes (format, spatial_shape, etc.)
  *   <root>/metadata/.zattrs     — semantic metadata
  *   <root>/axes/coordinates     — (n_pixels, 3) uint32, pixel coordinates


### PR DESCRIPTION
…for downloads

- Add en/zh "Downloading Data" doc pages and wire them into VitePress nav
- Require login before dataset download (removed public-page bypass) in useDatasetDetail
- Fix average spectrum dataZoom thumbnail: peak-preserving bucketed shadow series, align main chart axis extent with thumbnail extent, unclip edge bars
- Preserve zero-intensity samples in profile-mode spectra (only centroid mode filters zeros) to avoid fabricating signal across gaps
- Drop stale public/zarr_schema.md reference from zarrOssStore comment